### PR TITLE
Fix OTA using nRF toolbox on iPhone (tested on SE and XS)

### DIFF
--- a/lib/sdk11/components/libraries/bootloader_dfu/dfu_transport_ble.c
+++ b/lib/sdk11/components/libraries/bootloader_dfu/dfu_transport_ble.c
@@ -885,6 +885,22 @@ static void on_ble_evt(ble_evt_t * p_ble_evt)
           APP_ERROR_CHECK( sd_ble_gap_data_length_update(m_conn_handle, NULL, NULL) );
         break;
 
+        case BLE_GAP_EVT_PHY_UPDATE_REQUEST:
+        {
+//          ble_gap_phys_t* req_phy = &evt->evt.gap_evt.params.phy_update_request.peer_preferred_phys;
+
+          // Tell SoftDevice to choose PHY automatically
+          ble_gap_phys_t phy = { BLE_GAP_PHY_AUTO, BLE_GAP_PHY_AUTO };
+          (void) sd_ble_gap_phy_update(m_conn_handle, &phy);
+        }
+        break;
+
+        case BLE_GAP_EVT_PHY_UPDATE:
+        {
+//          ble_gap_evt_phy_update_t* active_phy = &evt->evt.gap_evt.params.phy_update;
+        }
+        break;
+
         case BLE_GATTS_EVT_EXCHANGE_MTU_REQUEST:
         {
           uint16_t att_mtu = MIN(p_ble_evt->evt.gatts_evt.params.exchange_mtu_request.client_rx_mtu, BLEGATT_ATT_MTU_MAX);

--- a/src/sdk_config.h
+++ b/src/sdk_config.h
@@ -64,7 +64,7 @@
 #define HCI_MEM_POOL_ENABLED               1
 #define HCI_TX_BUF_SIZE                    600
 #define HCI_RX_BUF_SIZE                    600
-#define HCI_RX_BUF_QUEUE_SIZE              4
+#define HCI_RX_BUF_QUEUE_SIZE              8
 
 //==========================================================
 // <e> UART_ENABLED - nrf_drv_uart - UART/UARTE peripheral driver


### PR DESCRIPTION
When using nRF Toolbox on iPhone XS for legacy DFU, it sends PHY UPDATE REQ but are not handled properly causing update to stuck.