### PR TITLE
increase buffer depth to fix OTA issue with nrfConnect on iOS

### DIFF
--- a/lib/sdk11/components/libraries/bootloader_dfu/dfu_single_bank.c
+++ b/lib/sdk11/components/libraries/bootloader_dfu/dfu_single_bank.c
@@ -154,7 +154,7 @@ static void dfu_prepare_func_app_erase(uint32_t image_size)
       nrf_nvmc_page_erase(DFU_BANK_0_REGION_START + i * CODE_PAGE_SIZE);
     }
 
-    // simulate complete call
+    // invoke complete callback
     pstorage_callback_handler(&m_storage_handle_app, PSTORAGE_CLEAR_OP_CODE, NRF_SUCCESS, NULL, 0);
   }
 }

--- a/src/boards.c
+++ b/src/boards.c
@@ -253,9 +253,9 @@ void led_state(uint32_t state)
         case STATE_BLE_CONNECTED:
           new_rgb_color = 0x0000ff;
           #ifdef LED_SECONDARY_PIN
-          secondary_cycle_length = 500;
+          secondary_cycle_length = 3000;
           #else
-          primary_cycle_length = 500;
+          primary_cycle_length = 3000;
           #endif
           break;
 

--- a/src/boards.h
+++ b/src/boards.h
@@ -96,4 +96,50 @@ static inline bool button_pressed(uint32_t pin)
 
 bool is_ota(void);
 
+//--------------------------------------------------------------------+
+// DEBUG
+//--------------------------------------------------------------------+
+//#define CFG_DEBUG
+
+#ifdef CFG_DEBUG
+
+#include <stdio.h>
+
+#define PRINT_LOCATION()      printf("%s: %d:\n", __PRETTY_FUNCTION__, __LINE__)
+#define PRINT_MESS(x)         printf("%s: %d: %s \n"   , __FUNCTION__, __LINE__, (char*)(x))
+#define PRTNT_HEAP()          if (CFG_DEBUG == 3) printf("\n%s: %d: Heap free: %d\n", __FUNCTION__, __LINE__, util_heap_get_free_size())
+#define PRINT_STR(x)          printf("%s: %d: " #x " = %s\n"   , __FUNCTION__, __LINE__, (char*)(x) )
+#define PRINT_INT(x)          printf("%s: %d: " #x " = %ld\n"  , __FUNCTION__, __LINE__, (uint32_t) (x) )
+#define PRINT_HEX(x)          printf("%s: %d: " #x " = 0x%X\n"  , __FUNCTION__, __LINE__, (uint32_t) (x) )
+
+#define PRINT_BUFFER(buf, n) \
+  do {\
+    uint8_t const* p8 = (uint8_t const*) (buf);\
+    printf(#buf ": ");\
+    for(uint32_t i=0; i<(n); i++) printf("%x ", p8[i]);\
+    printf("\n");\
+  }while(0)
+
+#define ADALOG(tag, ...) \
+  do { \
+    if ( tag ) printf("[%s] ", tag);\
+    printf(__VA_ARGS__);\
+    printf("\n");\
+  }while(0)
+
+#else
+
+#define PRINT_LOCATION()
+#define PRINT_MESS(x)
+#define PRTNT_HEAP()
+#define PRINT_STR(x)
+#define PRINT_INT(x)
+#define PRINT_HEX(x)
+#define PRINT_BUFFER(buf, n)
+
+#define ADALOG(...)
+
+#endif
+
+
 #endif

--- a/src/sdk_config.h
+++ b/src/sdk_config.h
@@ -64,9 +64,9 @@
 // <e> HCI_MEM_POOL_ENABLED - hci_mem_pool - memory pool implementation used by HCI
 //==========================================================
 #define HCI_MEM_POOL_ENABLED               1
-#define HCI_TX_BUF_SIZE                    600
+#define HCI_TX_BUF_SIZE                    600 // not used
 #define HCI_RX_BUF_SIZE                    600
-#define HCI_RX_BUF_QUEUE_SIZE              4
+#define HCI_RX_BUF_QUEUE_SIZE              8   // must be power of 2
 
 //==========================================================
 // <e> UART_ENABLED - nrf_drv_uart - UART/UARTE peripheral driver

--- a/src/segger/Adafruit_nRF52_Bootloader.emProject
+++ b/src/segger/Adafruit_nRF52_Bootloader.emProject
@@ -375,10 +375,12 @@
     <configuration
       Name="Feather52840"
       c_preprocessor_definitions="NRF52840_XXAA;MK_DIS_FIRMWARE=&quot;s140 6.1.1 r0&quot;;S140;BOARD_FEATHER_NRF52840_EXPRESS;BOARD_HEADER_FILE=&quot;feather_nrf52840_express.h&quot;"
+      gcc_optimization_level="Debug"
       linker_memory_map_file="nRF52840_xxAA_MemoryMap.xml" />
     <configuration
       Name="Feather52832"
       c_preprocessor_definitions="NRF52832_XXAA;MK_DIS_FIRMWARE=&quot;s132 6.1.1 r0&quot;;S132;BOARD_FEATHER_NRF52832;BOARD_HEADER_FILE=&quot;feather_nrf52832.h&quot;"
+      gcc_optimization_level="Debug"
       linker_memory_map_file="nRF52832_xxAA_MemoryMap.xml" />
     <configuration
       Name="PCA10056"


### PR DESCRIPTION
OTA issue discussed in forum
https://forums.adafruit.com/viewtopic.php?f=57&t=123583&p=729259#p729259

Reason is latest iOS and updated SD support multiple packets per connection interval (max 6 packets), which is quickly overflow the current buffer depth (previously = 4). Buffer depth is increased to 8 now. For Android, it doesn't seem to support multiple packets yet (at least on my 8.0.0 )

- also add optional debug helper
- increase led conn cycle when ble connected for easier recognition