### PR TITLE
Fix signed/unsigned bug.

### DIFF
--- a/src/usb/msc_uf2.c
+++ b/src/usb/msc_uf2.c
@@ -63,7 +63,7 @@ int write_block(uint32_t block_no, uint8_t *data, bool quiet, WriteState *state)
 int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, uint16_t bufsize)
 {
   void const* response = NULL;
-  uint16_t resplen = 0;
+  int32_t resplen = 0;
 
   switch ( scsi_cmd[0] )
   {
@@ -98,7 +98,7 @@ int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16], void* buffer, 
   }
 
   // return len must not larger than bufsize
-  if ( resplen > bufsize ) resplen = bufsize;
+  if ( resplen > (int32_t)bufsize ) resplen = bufsize;
 
   // copy response to stack's buffer if any
   if ( response && resplen )


### PR DESCRIPTION
Without this fix, any error will fail to be detected.
Specifically, because both ```resplen``` and ```bufsize``` were both ```uint16_t```, they could never store a negative value.  ```resplen``` was set to a negative value (```0xFFFF```), to indicate an error at line 93.

Then, line 101:
```if ( resplen > bufsize ) resplen = bufsize;```
would change the ```resplen`` from the error value of ```0xFFFF``` to the non-error value ```bufsize```, and TinyUSB would treat this as success.

The fix changes ```resplen``` from ```uint16_t``` to ```int16_t```, allowing it to store negative values, and explicitly upcasts ```bufsize``` from unsigned 16-bit to signed 32-bit value for the error check.