### PR TITLE
Add support for SparkFun Pro nRF52840 Mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a CDC/DFU/UF2 bootloader for nRF52 boards.
 - Particle Boron
 - Particle Xenon
 - MakerDiary MDK nRF52840 USB Dongle
+- SparkFun Pro nRF52840 Mini
 
 UF2 is an easy-to-use bootloader that appears as a flash drive. You can just copy `.uf2`-format
 application images to the flash drive to load new firmware.

--- a/src/boards/sparkfun_pro_nrf52840_mini.h
+++ b/src/boards/sparkfun_pro_nrf52840_mini.h
@@ -1,0 +1,76 @@
+/**************************************************************************/
+/*!
+    @file     sparkfun_pro_nrf52840_mini.h
+    @author   charlesportwoodii (https://www.erianna.com)
+
+    @section LICENSE
+
+    Software License Agreement (BSD License)
+
+    Copyright (c) 2019, Adafruit Industries (adafruit.com)
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holders nor the
+    names of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ''AS IS'' AND ANY
+    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+/**************************************************************************/
+
+#ifndef SPARKFUN_PRO_NRF52840_MINI_H
+#define SPARKFUN_PRO_NRF52840_MINI_H
+
+/*------------------------------------------------------------------*/
+/* LED
+ *------------------------------------------------------------------*/
+#define LEDS_NUMBER       1
+#define LED_PRIMARY_PIN   7  // Blue
+#define LED_STATE_ON      0
+
+/*------------------------------------------------------------------*/
+/* BUTTON
+ *------------------------------------------------------------------*/
+#define BUTTONS_NUMBER 2
+
+#define BUTTON_1       13
+#define BUTTON_2       2
+#define BUTTON_PULL    NRF_GPIO_PIN_PULLUP
+
+/*------------------------------------------------------------------*/
+/* UART
+ *------------------------------------------------------------------*/
+#define RX_PIN_NUMBER  15
+#define TX_PIN_NUMBER  17
+#define CTS_PIN_NUMBER 19
+#define RTS_PIN_NUMBER 20
+#define HWFC           false
+
+// Used as model string in OTA mode
+#define DIS_MANUFACTURER  "SparkFun"
+#define DIS_MODEL         "DEV-15025"
+
+#define PRODUCT_NAME      "SparkFun Pro nRF52840 Mini"
+#define VOLUME_LABEL      "SRPKFNP840M"
+
+#define BOARD_ID          "SparkFun-Pro-nRF52840-Mini"
+
+#define INDEX_URL         "https://www.sparkfun.com/products/15025"
+
+#endif // SPARKFUN_PRO_NRF52840_MINI_H


### PR DESCRIPTION
Adds support for the [SparkFun Pro nRF52840 Mini](https://www.sparkfun.com/products/15025).

SparkFun's documentation says this chip uses a bootloader "[heavily based upon](https://learn.sparkfun.com/tutorials/sparkfun-pro-nrf52840-mini-hookup-guide#using-the-bootloader)" this one. I wasn't able to find the actual bootloader hex they used or the changes they made though, so [after spending around a week](https://forum.sparkfun.com/viewtopic.php?f=114&t=49541&p=202928#p202928) trying to fix a bad flash from the factory I wanted see if we could get this "officially" supported.

I've tried to keep the setup in-line with what [SparkFun has in their documentation](https://learn.sparkfun.com/tutorials/sparkfun-pro-nrf52840-mini-hookup-guide).

The board has only a single blue LED and primarily can be reset via the double-reset trigger. [SparkFun's documentation](https://learn.sparkfun.com/tutorials/sparkfun-pro-nrf52840-mini-hookup-guide#using-the-bootloader) also states that you can reset it via PIN13 + RST and by grounding PIN 2. I've verified all 3 reset methods.

Please let me know if you'd like to see any changes before merging this in. Thanks!