### PR TITLE
fix for issue #70

### DIFF
--- a/lib/sdk11/components/libraries/bootloader_dfu/dfu_dual_bank.c
+++ b/lib/sdk11/components/libraries/bootloader_dfu/dfu_dual_bank.c
@@ -817,6 +817,9 @@ uint32_t dfu_sd_image_validate(void)
         uint32_t image_end       = bootloader_settings.sd_image_start + 
                                    bootloader_settings.sd_image_size;
 
+        /* ##### FIX START ##### */
+        block_size &= ~(uint32_t)(CODE_PAGE_SIZE - 1); 
+        /* ##### FIX END ##### */       
         uint32_t img_block_start = bootloader_settings.sd_image_start + 2 * block_size;
         uint32_t sd_block_start  = sd_start + 2 * block_size;
 

--- a/lib/sdk11/components/libraries/bootloader_dfu/dfu_single_bank.c
+++ b/lib/sdk11/components/libraries/bootloader_dfu/dfu_single_bank.c
@@ -790,6 +790,9 @@ uint32_t dfu_sd_image_validate(void)
         uint32_t image_end       = bootloader_settings.sd_image_start + 
                                    bootloader_settings.sd_image_size;
 
+        /* ##### FIX START ##### */
+        block_size &= ~(uint32_t)(CODE_PAGE_SIZE - 1); 
+        /* ##### FIX END ##### */       
         uint32_t img_block_start = bootloader_settings.sd_image_start + 2 * block_size;
         uint32_t sd_block_start  = sd_start + 2 * block_size;
 


### PR DESCRIPTION
Fix also dfu_sd_image_validate method in single and dual bank code as per https://devzone.nordicsemi.com/f/nordic-q-a/16774/updating-from-s132-v2-0-x-to-s132-v3-0-0-with-dual-bank-bootloader-from-sdk-v11-0-0-does-not-work/185106#185106

This dfu_sd_image_validate code path is called when recovering from power failure or reset and incomplete SoftDevice copy needs to be finished.