### PR TITLE
Add check for button direction

### DIFF
--- a/src/boards.c
+++ b/src/boards.c
@@ -42,12 +42,16 @@
 //------------- IMPLEMENTATION -------------//
 void button_init(uint32_t pin)
 {
-  nrf_gpio_cfg_sense_input(pin, BUTTON_PULL, NRF_GPIO_PIN_SENSE_LOW);
+  if (BUTTON_PULL == NRF_GPIO_PIN_PULLDOWN) {
+    nrf_gpio_cfg_sense_input(pin, BUTTON_PULL, NRF_GPIO_PIN_SENSE_HIGH);
+  } else {
+    nrf_gpio_cfg_sense_input(pin, BUTTON_PULL, NRF_GPIO_PIN_SENSE_LOW);
+  }
 }
 
 bool button_pressed(uint32_t pin)
 {
-  return (nrf_gpio_pin_read(pin) == 0) ? true : false;
+  return (nrf_gpio_pin_read(pin) == BUTTON_DIR) ? true : false;
 }
 
 void board_init(void)

--- a/src/boards.h
+++ b/src/boards.h
@@ -38,6 +38,13 @@
 #ifndef BUTTON_FRESET
 #define BUTTON_FRESET   BUTTON_2
 #endif
+#ifndef BUTTON_DIR
+#if BUTTON_PULL == NRF_GPIO_PIN_PULLDOWN
+  #define BUTTON_DIR   1
+#elif BUTTON_PULL == NRF_GPIO_PIN_PULLUP
+  #define BUTTON_DIR   0
+#endif
+#endif
 
 // The primary LED is usually Red but not in all cases.
 #define LED_PRIMARY 0


### PR DESCRIPTION
boards.c incorrectly assumes that an active low state indicates that a button is pressed.
```
bool button_pressed(uint32_t pin)
{
  return (nrf_gpio_pin_read(pin) == 0) ? true : false;
}
```
This is not true with devices like the Circuit Playground Bluefruit where the buttons have an active high state and causes the issue described in #76.

This PR adds a new def `BUTTON_DIR` to check _nrf_gpio_pin_read_ against. `BUTTON_DIR` is inferred from `BUTTON_PULL` which is already defined in the custom board files.

