### PR TITLE
Increased `HCI_RX_BUF_QUEUE_SIZE` to 16 to Resolve OTA DFU

### DIFF
--- a/src/sdk_config.h
+++ b/src/sdk_config.h
@@ -66,7 +66,7 @@
 #define HCI_MEM_POOL_ENABLED               1
 #define HCI_TX_BUF_SIZE                    600 // not used
 #define HCI_RX_BUF_SIZE                    600
-#define HCI_RX_BUF_QUEUE_SIZE              8   // must be power of 2
+#define HCI_RX_BUF_QUEUE_SIZE              16   // must be power of 2
 
 //==========================================================
 // <e> UART_ENABLED - nrf_drv_uart - UART/UARTE peripheral driver


### PR DESCRIPTION
Using a Segger J-Link, I traced the following error, thrown by `hci_mem_pool_rx_produce()`:
`NRF_ERROR_NO_MEM due to m_rx_buffer_queue.free_window_count == 0`

In that trace, the value of `length`, being passed to `hci_mem_pool_rx_produce()` was `14`. Alas, increasing `HCI_RX_BUF_QUEUE_SIZE` resolved the issue. I have quite a handful of these boards, and the error was consistently resolved across the board in both my iOS and Android app.

nRF52 Device Information:
```
MCU Variant						= nRF52840	0x41414330
Memory (FLASH)					= 1024 KB
Memory (RAM)					= 256 KB
ARM Cortex-M4 Processor Revision	= v1
MDK Version						= v8.24.1
TinyUSB Version					= v0.5.0
LittleFS Version					= v1.1
Bootloader/DFU Revision			= s140 6.1.1
SoftDevice Version				= v6.1.1
BSP Library						= v0.14.0
```

Desktop Platform Information: macOS 10.14, as well as 10.15
Mobile Devices Used: An iPhone 8 (iOS 11 + 12) as well as an iPhone X (iOS 12 + 13)