### PR TITLE
correct LED1 pin; make volume label FTHRSNSBOOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ _build-*/
 bin/
 *.emSession
 *.jlink
+
+TAGS

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Adafruit nRF52 Bootloader Changelog
 
+## 0.3.1 - 2020.03.05
+- Correct LED1 for Feather Sense and change volume name to FTHRSNSBOOT.
+
 ## 0.3.0 - 2020.01.13
 
 - Upgrade nrfx to v2 for supporting future nrf mcu such as nrf52833, nrf5340
@@ -29,7 +32,7 @@
 - NFC pins are forced to GPIO mode by bootloader
 - Added Metro nRF52840 Express VID/PID
 - Enhance board management
-- Added electronut/papyr_support 
+- Added electronut/papyr_support
 
 ## 0.2.9
 
@@ -45,7 +48,7 @@
 - Fixed PWM psel[1] is not reset
 - Fixed #41 move RXD, TXD into board header
 - Added Metro nRF52840 Rev A
-- Fixed #40 OTA issue with BLE_GAP_EVT_PHY_UPDATE_REQUEST e.g connecting with iPhone X  
+- Fixed #40 OTA issue with BLE_GAP_EVT_PHY_UPDATE_REQUEST e.g connecting with iPhone X
 
 ## 0.2.6
 
@@ -63,4 +66,3 @@
 - Fully support Feather nRF52840
 - Update bootloader with new led pattern
 - Fix #203: return software timer handle
-

--- a/src/boards/feather_nrf52840_sense/board.h
+++ b/src/boards/feather_nrf52840_sense/board.h
@@ -31,7 +31,7 @@
 /* LED
  *------------------------------------------------------------------*/
 #define LEDS_NUMBER           2
-#define LED_PRIMARY_PIN       _PINNUM(1, 15)
+#define LED_PRIMARY_PIN       _PINNUM(1, 9)
 #define LED_SECONDARY_PIN     _PINNUM(1, 10)
 #define LED_STATE_ON          1
 
@@ -71,7 +71,7 @@
 
 //------------- UF2 -------------//
 #define UF2_PRODUCT_NAME      "Adafruit Feather nRF52840 Sense"
-#define UF2_VOLUME_LABEL      "FTHR840BOOT"
+#define UF2_VOLUME_LABEL      "FTHRSNSBOOT"
 #define UF2_BOARD_ID          "nRF52840-Feather-Sense"
 #define UF2_INDEX_URL         "https://www.adafruit.com/product/4516"
 


### PR DESCRIPTION
- Feather Sense had wrong LED1 pin, so there was no pulsing LED when bootloader running.
- Changed volume label from `FTHR840BOOT` to `FTHRSNSBOOT` to distinguish this from the regular Feather nRF52840.