### PR TITLE
Make sure all pins are in reset state on teardown

### DIFF
--- a/src/boards.c
+++ b/src/boards.c
@@ -115,6 +115,13 @@ void board_teardown(void)
 
   // Stop LF clock
   NRF_CLOCK->TASKS_LFCLKSTOP = 1UL;
+
+  // make sure all pins are back in reset state
+  for (int i = 0; i < 32; ++i)
+  {
+    NRF_P0->PIN_CNF[i] = 2;
+    NRF_P1->PIN_CNF[i] = 2;
+  }
 }
 
 static uint32_t _systick_count = 0;

--- a/src/boards.c
+++ b/src/boards.c
@@ -120,7 +120,9 @@ void board_teardown(void)
   for (int i = 0; i < 32; ++i)
   {
     NRF_P0->PIN_CNF[i] = 2;
+#ifdef NRF_P1
     NRF_P1->PIN_CNF[i] = 2;
+#endif
   }
 }
 


### PR DESCRIPTION
In particular, the button pins are left configured with sense, which may (and did in my case) wreak havoc in the application.