### PR TITLE
Enable large volume size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@
 *.x86_64
 #*.hex
 
+# VSCode files
+.vscode/
+
 # Debug files
 *.dSYM/
 *.su

--- a/src/usb/uf2/ghostfat.c
+++ b/src/usb/uf2/ghostfat.c
@@ -300,11 +300,11 @@ void read_block(uint32_t block_no, uint8_t *data) {
             d->createTime       = __DOSTIME__;
             d->createDate       = __DOSDATE__;
             d->lastAccessDate   = __DOSDATE__;
-            d->highStartCluster = startCluster >> 8; // BUGBUG -- shouldn't this be 16?
+            d->highStartCluster = startCluster >> 16;
             // DIR_WrtTime and DIR_WrtDate must be supported
             d->updateTime       = __DOSTIME__;
             d->updateDate       = __DOSDATE__;
-            d->startCluster     = startCluster & 0xFF; // BUGBUG -- shouldn't this be 0xFFFF?
+            d->startCluster     = startCluster & 0xFFFF;
             d->size = (inf->content ? strlen(inf->content) : UF2_SIZE);
         }
 

--- a/src/usb/uf2/ghostfat.c
+++ b/src/usb/uf2/ghostfat.c
@@ -65,6 +65,10 @@ struct TextFile {
 
 #define NUM_FAT_BLOCKS CFG_UF2_NUM_BLOCKS
 
+#define RESERVED_SECTORS   1
+#define ROOT_DIR_SECTORS   4
+#define SECTORS_PER_FAT    ((NUM_FAT_BLOCKS * 2 + 511) / 512)
+
 #define STR0(x) #x
 #define STR(x) STR0(x)
 
@@ -105,10 +109,6 @@ STATIC_ASSERT(ARRAY_SIZE(indexFile) < 512);
 #define UF2_FIRST_SECTOR   (NUM_FILES + 1) // WARNING -- code presumes each non-UF2 file content fits in single sector
 #define UF2_LAST_SECTOR    (UF2_FIRST_SECTOR + UF2_SECTORS - 1)
 
-#define RESERVED_SECTORS   1
-#define ROOT_DIR_SECTORS   4
-#define SECTORS_PER_FAT    ((NUM_FAT_BLOCKS * 2 + 511) / 512)
-
 #define START_FAT0         RESERVED_SECTORS
 #define START_FAT1         (START_FAT0 + SECTORS_PER_FAT)
 #define START_ROOTDIR      (START_FAT1 + SECTORS_PER_FAT)
@@ -119,7 +119,6 @@ STATIC_ASSERT(ARRAY_SIZE(indexFile) < 512);
 #define DIRENTRIES_PER_SECTOR (512/sizeof(DirEntry))
 
 STATIC_ASSERT(NUM_DIRENTRIES < DIRENTRIES_PER_SECTOR * ROOT_DIR_SECTORS);
-
 
 static FAT_BootBlock const BootBlock = {
     .JumpInstruction      = {0xeb, 0x3c, 0x90},

--- a/src/usb/uf2/ghostfat.c
+++ b/src/usb/uf2/ghostfat.c
@@ -68,8 +68,7 @@ struct TextFile {
 #define BPB_RESERVED_SECTORS      (   1)
 #define BPB_NUMBER_OF_FATS        (   2)
 #define BPB_ROOT_DIR_ENTRIES      (  64)
-// #define BPB_TOTAL_SECTORS         CFG_UF2_NUM_BLOCKS
-#define BPB_TOTAL_SECTORS         (0x101dd) // 0x101dd is absolute max at current code commit
+#define BPB_TOTAL_SECTORS         CFG_UF2_NUM_BLOCKS // 0x101dd is absolute max at current code commit
 #define BPB_MEDIA_DESCRIPTOR_BYTE (0xF8)
 #define FAT_ENTRY_SIZE            (2)
 #define FAT_ENTRIES_PER_SECTOR    (BPB_SECTOR_SIZE / FAT_ENTRY_SIZE)
@@ -163,11 +162,12 @@ static FAT_BootBlock const BootBlock = {
     .ReservedSectors      = BPB_RESERVED_SECTORS,
     .FATCopies            = BPB_NUMBER_OF_FATS,
     .RootDirectoryEntries = BPB_ROOT_DIR_ENTRIES,
-    .TotalSectors16       = BPB_TOTAL_SECTORS,
+    .TotalSectors16       = (BPB_TOTAL_SECTORS > 0xFFFF) ? 0 : BPB_TOTAL_SECTORS,
     .MediaDescriptor      = BPB_MEDIA_DESCRIPTOR_BYTE,
     .SectorsPerFAT        = BPB_SECTORS_PER_FAT,
     .SectorsPerTrack      = 1,
     .Heads                = 1,
+    .TotalSectors32       = (BPB_TOTAL_SECTORS > 0xFFFF) ? BPB_TOTAL_SECTORS : 0,
     .PhysicalDriveNum     = 0x80, // to match MediaDescriptor of 0xF8
     .ExtendedBootSig      = 0x29,
     .VolumeSerialNumber   = 0x00420042,

--- a/src/usb/uf2/ghostfat.c
+++ b/src/usb/uf2/ghostfat.c
@@ -68,7 +68,7 @@ struct TextFile {
 #define BPB_RESERVED_SECTORS      (   1)
 #define BPB_NUMBER_OF_FATS        (   2)
 #define BPB_ROOT_DIR_ENTRIES      (  64)
-#define BPB_TOTAL_SECTORS         CFG_UF2_NUM_BLOCKS // 0x101dd is absolute max at current code commit
+#define BPB_TOTAL_SECTORS         (0x10109) // Use a fixed (near max) number of sectors for the FAT file system
 #define BPB_MEDIA_DESCRIPTOR_BYTE (0xF8)
 #define FAT_ENTRY_SIZE            (2)
 #define FAT_ENTRIES_PER_SECTOR    (BPB_SECTOR_SIZE / FAT_ENTRY_SIZE)
@@ -77,6 +77,10 @@ struct TextFile {
                                    ((BPB_TOTAL_SECTORS % FAT_ENTRIES_PER_SECTOR) ? 1 : 0))
 #define DIRENTRIES_PER_SECTOR     (BPB_SECTOR_SIZE/sizeof(DirEntry))
 #define ROOT_DIR_SECTOR_COUNT     (BPB_ROOT_DIR_ENTRIES/DIRENTRIES_PER_SECTOR)
+
+#if defined(CFG_UF2_NUM_BLOCKS)
+  STATIC_ASSERT(BPB_TOTAL_SECTORS >= CFG_UF2_NUM_BLOCKS); // configuration used, and asked for a larger size GhostFAT?
+#endif
 
 STATIC_ASSERT(BPB_SECTOR_SIZE                              ==       512); // GhostFAT does not support other sector sizes (currently)
 STATIC_ASSERT(BPB_SECTORS_PER_CLUSTER                      ==         1); // GhostFAT presumes one sector == one cluster (for simplicity)


### PR DESCRIPTION
# Enable large (~31MB) volume size in GhostFAT

This also includes a fix for #133 via 3b92ef8.

I can easily open a PR on master later, no problem.