### PR TITLE
Place data from .uicrREGOUT0 into UICR.REGOUT0 flash word.

### DIFF
--- a/linker/nrf52833.ld
+++ b/linker/nrf52833.ld
@@ -39,6 +39,16 @@ MEMORY
     
   /** Location in UICR where mbr params page address is stored. */
   UICR_MBR_PARAM_PAGE(r) : ORIGIN = 0x10001018, LENGTH = 0x04
+
+  /** Location in UICR of REGOUT0 (used to set voltage levels for VCC at boot)
+   *
+   * IMPORTANT NOTE: This controls the voltage provided on the VCC output of the CPU. Changing this value from the default
+   * can physically damage parts on your board.  If using a SWD debugger you should consider connecting the Vref input
+   * for that debugger to the VCC rail. Think carefully before using this feature.
+   * Example usage:
+   * __attribute__ ((section(".uicrREGOUT0"))) volatile uint32_t m_uicr_regout0 = 0xfffffff4;
+   */
+  UICR_REGOUT0(r) : ORIGIN = 0x10001304, LENGTH = 0x04
 }
 
 SECTIONS
@@ -73,6 +83,12 @@ SECTIONS
   {
     KEEP(*(.uicrMbrParamsPageAddress))
   } > UICR_MBR_PARAM_PAGE
+
+  /* Write REGOUT0 in UICR. */
+  .uicrREGOUT0 :
+  {
+    KEEP(*(.uicrREGOUT0))
+  } > UICR_REGOUT0
 
   .dbl_reset(NOLOAD) :
   {

--- a/linker/nrf52840.ld
+++ b/linker/nrf52840.ld
@@ -41,6 +41,9 @@ MEMORY
   
   /** Location in UICR where mbr params page address is stored. */
   UICR_MBR_PARAM_PAGE(r) : ORIGIN = 0x10001018, LENGTH = 0x04
+
+  /** Location in UICR of REGOUT0 (used to set voltage levels for VCC at boot) */
+  UICR_REGOUT0(r) : ORIGIN = 0x10001304, LENGTH = 0x04
 }
 
 SECTIONS
@@ -80,6 +83,12 @@ SECTIONS
   {
     KEEP(*(.uicrMbrParamsPageAddress))
   } > UICR_MBR_PARAM_PAGE
+
+  /* Write REGOUT0 in UICR. */
+  .uicrREGOUT0 :
+  {
+    KEEP(*(.uicrREGOUT0))
+  } > UICR_REGOUT0
 
   .dbl_reset(NOLOAD) :
   {

--- a/linker/nrf52840.ld
+++ b/linker/nrf52840.ld
@@ -42,7 +42,14 @@ MEMORY
   /** Location in UICR where mbr params page address is stored. */
   UICR_MBR_PARAM_PAGE(r) : ORIGIN = 0x10001018, LENGTH = 0x04
 
-  /** Location in UICR of REGOUT0 (used to set voltage levels for VCC at boot) */
+  /** Location in UICR of REGOUT0 (used to set voltage levels for VCC at boot)
+   *
+   * IMPORTANT NOTE: This controls the voltage provided on the VCC output of the CPU. Changing this value from the default
+   * can physically damage parts on your board.  If using a SWD debugger you should consider connecting the Vref input
+   * for that debugger to the VCC rail. Think carefully before using this feature.
+   * Example usage:
+   * __attribute__ ((section(".uicrREGOUT0"))) volatile uint32_t m_uicr_regout0 = 0xfffffff4;
+   */
   UICR_REGOUT0(r) : ORIGIN = 0x10001304, LENGTH = 0x04
 }
 


### PR DESCRIPTION
The REGOUT0 flash register to set VCC voltage upon power-up.  This adds support to allow optionally setting that register in the generated hex file (similar to the other UICR words you already support).

If not used, there is no change to the output files.

Example usage from my board's pinconfig.c file:

```
 __attribute__ ((section(".uicrREGOUT0"))) volatile uint32_t m_uicr_regout0 = 0xfffffff4;
```

(These are a few commits I thought might be useful after bringing up an open-source radio board - I can send in the changes for that board if you want it (once the next spin comes back and we test it)?)