### PR TITLE
Reset into app, if no USB connection in 3s

### DIFF
--- a/lib/sdk11/components/libraries/bootloader_dfu/bootloader.c
+++ b/lib/sdk11/components/libraries/bootloader_dfu/bootloader.c
@@ -49,8 +49,7 @@ typedef enum
 
 static pstorage_handle_t        m_bootsettings_handle;  /**< Pstorage handle to use for registration and identifying the bootloader module on subsequent calls to the pstorage module for load and store of bootloader setting in flash. */
 static bootloader_status_t      m_update_status;        /**< Current update status for the bootloader module to ensure correct behaviour when updating settings and when update completes. */
-
-static bool m_cancel_timeout_on_usb;
+static bool m_cancel_timeout_on_usb; /**< If set the timeout is cancelled when USB is enumerated. Otherwise, the timeout is only cancelled when DFU update is started. */
 
 APP_TIMER_DEF( _dfu_startup_timer );
 volatile bool dfu_startup_packet_received = false;
@@ -326,7 +325,7 @@ uint32_t bootloader_dfu_start(bool ota, uint32_t timeout_ms, bool cancel_timeout
 {
     uint32_t err_code;
 
-    m_cancel_timeout_on_usb = cancel_timeout_on_usb;
+    m_cancel_timeout_on_usb = cancel_timeout_on_usb && !ota;
 
     // Clear swap if banked update is used.
     err_code = dfu_init();

--- a/lib/sdk11/components/libraries/bootloader_dfu/bootloader.h
+++ b/lib/sdk11/components/libraries/bootloader_dfu/bootloader.h
@@ -42,7 +42,7 @@ bool bootloader_app_is_valid(void);
  * 
  * @retval     NRF_SUCCESS If new application image was successfully transferred.
  */
-uint32_t bootloader_dfu_start(bool ota, uint32_t timeout_ms);
+uint32_t bootloader_dfu_start(bool ota, uint32_t timeout_ms, bool cancel_timeout_on_usb);
 
 /**@brief Function for exiting bootloader and booting into application.
  *

--- a/src/main.c
+++ b/src/main.c
@@ -252,10 +252,12 @@ int main(void)
     // Initiate an update of the firmware.
     if (APP_ASKS_FOR_SINGLE_TAP_RESET())
     {
+      // If USB is not enumerated in 3s (eg. because we're running on battery), we restart into app.
       APP_ERROR_CHECK( bootloader_dfu_start(_ota_dfu, 3000, true) );
     }
     else
     {
+      // No timeout if bootloader requires user action (double-reset).
       APP_ERROR_CHECK( bootloader_dfu_start(_ota_dfu, 0, false) );
     }
 

--- a/src/main.c
+++ b/src/main.c
@@ -223,7 +223,7 @@ int main(void)
      * Note: Supposedly during this time if RST is press, it will count as double reset.
      * However Double Reset WONT work with nrf52832 since its SRAM got cleared anyway.
      */
-    bootloader_dfu_start(false, DFU_SERIAL_STARTUP_INTERVAL);
+    bootloader_dfu_start(false, DFU_SERIAL_STARTUP_INTERVAL, false);
 #else
     // if RST is pressed during this delay --> if will enter dfu
     NRFX_DELAY_MS(DFU_DBL_RESET_DELAY);
@@ -250,7 +250,14 @@ int main(void)
     }
 
     // Initiate an update of the firmware.
-    APP_ERROR_CHECK( bootloader_dfu_start(_ota_dfu, 0) );
+    if (APP_ASKS_FOR_SINGLE_TAP_RESET())
+    {
+      APP_ERROR_CHECK( bootloader_dfu_start(_ota_dfu, 3000, true) );
+    }
+    else
+    {
+      APP_ERROR_CHECK( bootloader_dfu_start(_ota_dfu, 0, false) );
+    }
 
     if ( _ota_dfu )
     {


### PR DESCRIPTION
This only applies in SINGLE_TAP_RESET mode (MakeCode) - in that mode the board goes into bootloader by default for easy programming. However, if the board is not connected to computer, we should go into app (this is what we do on SAMD and STM32). This sets a 3000ms timeout if the USB is not enumerated.

Note, that such long delay was needed for certain versions of macOS - 10.14.4 until, but not including, Catalina.