### PR TITLE
Change delimiter in git submodule cut to double quote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ MBR_HEX			 = lib/softdevice/mbr/hex/mbr_nrf52_2.4.1_mbr.hex
 # linker by MCU eg. nrf52840.ld
 LD_FILE      = linker/$(MCU_SUB_VARIANT).ld
 
-GIT_VERSION = $(shell git describe --dirty --always --tags)
-GIT_SUBMODULE_VERSIONS = $(shell git submodule status | cut -d" " -f3,4 | paste -s -d" " -)
+GIT_VERSION != git describe --dirty --always --tags
+GIT_SUBMODULE_VERSIONS != git submodule status | cut -d" " -f3,4 | paste -s -d" " -
 
 # compiled file name
 OUT_FILE = $(BOARD)_bootloader-$(GIT_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ MBR_HEX			 = lib/softdevice/mbr/hex/mbr_nrf52_2.4.1_mbr.hex
 LD_FILE      = linker/$(MCU_SUB_VARIANT).ld
 
 GIT_VERSION = $(shell git describe --dirty --always --tags)
-GIT_SUBMODULE_VERSIONS = $(shell git submodule status | cut -d' ' -f3,4 | paste -s -d" " -)
+GIT_SUBMODULE_VERSIONS = $(shell git submodule status | cut -d" " -f3,4 | paste -s -d" " -)
 
 # compiled file name
 OUT_FILE = $(BOARD)_bootloader-$(GIT_VERSION)


### PR DESCRIPTION
The single quote causes issues with the string parsing on shells that expect double quotes.

In particular, I'm building on windows, and my cut/paste commands are standard win32 binaries. The shell invocation from make causes the quote to make cut very grumpy, and it while building is still possible, the version defines don't make it to the CC commands nicely.

I think this qualifies as my requisite first world problem of the week. 😂