### PR TITLE
Fixing Windows not playing nicely with mkdir.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,14 @@ GDB     = $(CROSS_COMPILE)gdb
 NRFUTIL = adafruit-nrfutil
 NRFJPROG = nrfjprog
 
-MK = mkdir -p
-RM = rm -rf
+# Set make directory command, Windows tries to create a directory named "-p" if that flag is there.
+ifneq ($(OS), Windows_NT)
+MK := mkdir -p
+else
+MK := mkdir
+endif
+
+RM := rm -rf
 
 # auto-detect BMP on macOS, otherwise have to specify
 BMP_PORT ?= $(shell ls -1 /dev/cu.usbmodem????????1 | head -1)
@@ -324,7 +330,7 @@ print-%:
 
 # Create build directories
 $(BUILD):
-	@$(MK) $@
+	@$(MK) "$@"
 
 clean:
 	@$(RM) $(BUILD)

--- a/Makefile
+++ b/Makefile
@@ -49,12 +49,12 @@ NRFJPROG = nrfjprog
 
 # Set make directory command, Windows tries to create a directory named "-p" if that flag is there.
 ifneq ($(OS), Windows_NT)
-MK = mkdir -p
+  MK = mkdir -p
 else
-MK = mkdir
+  MK = mkdir
 endif
 
-RM := rm -rf
+RM = rm -rf
 
 # auto-detect BMP on macOS, otherwise have to specify
 BMP_PORT ?= $(shell ls -1 /dev/cu.usbmodem????????1 | head -1)

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,9 @@ NRFJPROG = nrfjprog
 
 # Set make directory command, Windows tries to create a directory named "-p" if that flag is there.
 ifneq ($(OS), Windows_NT)
-MK := mkdir -p
+MK = mkdir -p
 else
-MK := mkdir
+MK = mkdir
 endif
 
 RM := rm -rf


### PR DESCRIPTION
I really don't know why Windows is such a pain sometimes:
 * The `-p` doesn't get handled as a switch, and instead actually creates a directory named "-p"...
 * The forward slash in the path being created causes cmd.exe to be sad instead of interpreting it as a path. Quotes around the path makes it happy.

One day things will be sane on Windows.

Today is not that day. 😂