### PR TITLE
Enable board-specific UF2 family IDs

### DIFF
--- a/src/usb/uf2/ghostfat.c
+++ b/src/usb/uf2/ghostfat.c
@@ -363,12 +363,7 @@ void read_block(uint32_t block_no, uint8_t *data) {
                 bl->targetAddr = addr;
                 bl->payloadSize = UF2_FIRMWARE_BYTES_PER_SECTOR;
                 bl->flags = UF2_FLAG_FAMILYID;
-
-#if defined(CFG_UF2_BOARD_APP_ID) && CFG_UF2_BOARD_APP_ID
                 bl->familyID = CFG_UF2_BOARD_APP_ID;
-#else
-                bl->familyID = CFG_UF2_FAMILY_APP_ID;
-#endif
                 memcpy(bl->data, (void *)addr, bl->payloadSize);
             }
         }
@@ -395,12 +390,8 @@ int write_block (uint32_t block_no, uint8_t *data, WriteState *state)
 
   switch ( bl->familyID )
   {
-
-#if defined(CFG_UF2_BOARD_APP_ID) && CFG_UF2_BOARD_APP_ID
     case CFG_UF2_BOARD_APP_ID:  // board-specific app ... may not be usable on other nrf52 boards
-#endif
-
-    case CFG_UF2_FAMILY_APP_ID: // legacy, or where app uses bootloader configuration to discover pins
+    case CFG_UF2_FAMILY_APP_ID: // family-specific app ... Legacy apps, or where the app uses bootloader configuration to discover pins
       /* Upgrading Application
        *
        * SoftDevice is considered as part of application and can be (or not) included in uf2.

--- a/src/usb/uf2/ghostfat.c
+++ b/src/usb/uf2/ghostfat.c
@@ -363,12 +363,7 @@ void read_block(uint32_t block_no, uint8_t *data) {
                 bl->targetAddr = addr;
                 bl->payloadSize = UF2_FIRMWARE_BYTES_PER_SECTOR;
                 bl->flags = UF2_FLAG_FAMILYID;
-
-#if defined(CFG_UF2_BOARD_APP_ID) && CFG_UF2_BOARD_APP_ID
                 bl->familyID = CFG_UF2_BOARD_APP_ID;
-#else
-                bl->familyID = CFG_UF2_FAMILY_APP_ID;
-#endif
                 memcpy(bl->data, (void *)addr, bl->payloadSize);
             }
         }

--- a/src/usb/uf2/ghostfat.c
+++ b/src/usb/uf2/ghostfat.c
@@ -363,7 +363,13 @@ void read_block(uint32_t block_no, uint8_t *data) {
                 bl->targetAddr = addr;
                 bl->payloadSize = UF2_FIRMWARE_BYTES_PER_SECTOR;
                 bl->flags = UF2_FLAG_FAMILYID;
-                bl->familyID = CFG_UF2_FAMILY_APP_ID;
+
+                bool useBoardId = false; // BUGBUG -- how to detect which familyID to use?
+                if (useBoardId) {
+                  bl->familyID = CFG_UF2_BOARD_APP_ID;
+                } else {
+                  bl->familyID = CFG_UF2_FAMILY_APP_ID;
+                }
                 memcpy(bl->data, (void *)addr, bl->payloadSize);
             }
         }
@@ -390,7 +396,8 @@ int write_block (uint32_t block_no, uint8_t *data, WriteState *state)
 
   switch ( bl->familyID )
   {
-    case CFG_UF2_FAMILY_APP_ID:
+    case CFG_UF2_BOARD_APP_ID:  // board-specific app ... may not be usable on other nrf52 boards
+    case CFG_UF2_FAMILY_APP_ID: // legacy, or where app uses bootloader configuration to discover pins
       /* Upgrading Application
        *
        * SoftDevice is considered as part of application and can be (or not) included in uf2.

--- a/src/usb/uf2/ghostfat.c
+++ b/src/usb/uf2/ghostfat.c
@@ -363,7 +363,12 @@ void read_block(uint32_t block_no, uint8_t *data) {
                 bl->targetAddr = addr;
                 bl->payloadSize = UF2_FIRMWARE_BYTES_PER_SECTOR;
                 bl->flags = UF2_FLAG_FAMILYID;
+
+#if defined(CFG_UF2_BOARD_APP_ID) && CFG_UF2_BOARD_APP_ID
                 bl->familyID = CFG_UF2_BOARD_APP_ID;
+#else
+                bl->familyID = CFG_UF2_FAMILY_APP_ID;
+#endif
                 memcpy(bl->data, (void *)addr, bl->payloadSize);
             }
         }
@@ -390,8 +395,12 @@ int write_block (uint32_t block_no, uint8_t *data, WriteState *state)
 
   switch ( bl->familyID )
   {
+
+#if defined(CFG_UF2_BOARD_APP_ID) && CFG_UF2_BOARD_APP_ID
     case CFG_UF2_BOARD_APP_ID:  // board-specific app ... may not be usable on other nrf52 boards
-    case CFG_UF2_FAMILY_APP_ID: // family-specific app ... Legacy apps, or where the app uses bootloader configuration to discover pins
+#endif
+
+    case CFG_UF2_FAMILY_APP_ID: // legacy, or where app uses bootloader configuration to discover pins
       /* Upgrading Application
        *
        * SoftDevice is considered as part of application and can be (or not) included in uf2.

--- a/src/usb/uf2/ghostfat.c
+++ b/src/usb/uf2/ghostfat.c
@@ -364,12 +364,11 @@ void read_block(uint32_t block_no, uint8_t *data) {
                 bl->payloadSize = UF2_FIRMWARE_BYTES_PER_SECTOR;
                 bl->flags = UF2_FLAG_FAMILYID;
 
-                bool useBoardId = false; // BUGBUG -- how to detect which familyID to use?
-                if (useBoardId) {
-                  bl->familyID = CFG_UF2_BOARD_APP_ID;
-                } else {
-                  bl->familyID = CFG_UF2_FAMILY_APP_ID;
-                }
+#if defined(CFG_UF2_BOARD_APP_ID) && CFG_UF2_BOARD_APP_ID
+                bl->familyID = CFG_UF2_BOARD_APP_ID;
+#else
+                bl->familyID = CFG_UF2_FAMILY_APP_ID;
+#endif
                 memcpy(bl->data, (void *)addr, bl->payloadSize);
             }
         }
@@ -396,7 +395,11 @@ int write_block (uint32_t block_no, uint8_t *data, WriteState *state)
 
   switch ( bl->familyID )
   {
+
+#if defined(CFG_UF2_BOARD_APP_ID) && CFG_UF2_BOARD_APP_ID
     case CFG_UF2_BOARD_APP_ID:  // board-specific app ... may not be usable on other nrf52 boards
+#endif
+
     case CFG_UF2_FAMILY_APP_ID: // legacy, or where app uses bootloader configuration to discover pins
       /* Upgrading Application
        *

--- a/src/usb/uf2/ghostfat.c
+++ b/src/usb/uf2/ghostfat.c
@@ -391,10 +391,7 @@ int write_block (uint32_t block_no, uint8_t *data, WriteState *state)
   switch ( bl->familyID )
   {
 
-#if defined(CFG_UF2_BOARD_APP_ID) && CFG_UF2_BOARD_APP_ID
     case CFG_UF2_BOARD_APP_ID:  // board-specific app ... may not be usable on other nrf52 boards
-#endif
-
     case CFG_UF2_FAMILY_APP_ID: // legacy, or where app uses bootloader configuration to discover pins
       /* Upgrading Application
        *

--- a/src/usb/uf2/uf2cfg.h
+++ b/src/usb/uf2/uf2cfg.h
@@ -1,15 +1,13 @@
 #include "boards.h"
 #include "dfu_types.h"
 
-#if !defined(USB_DESC_VID) || !defined(USB_DESC_UF2_PID) || !USB_DESC_VID || !USB_DESC_UF2_PID
-    #error "Per @hathach, 'This repo doesn't accept nrf52840/833 that doesn't have VID/PID'"
-#endif
-
-
-// Family ID for updating Application
+// Legacy Family ID for updating Application
 #define CFG_UF2_FAMILY_APP_ID     0xADA52840
-// Board ID for board-specific Application
-#define CFG_UF2_BOARD_APP_ID      ((USB_DESC_VID << 16) | USB_DESC_UF2_PID)
+
+// Family ID for board-specific Application
+#if defined(USB_DESC_VID) && defined(USB_DESC_UF2_PID) && USB_DESC_VID && USB_DESC_UF2_PID
+    #define CFG_UF2_BOARD_APP_ID      ((USB_DESC_VID << 16) | USB_DESC_UF2_PID)
+#endif
 
 
 // Family ID for updating Bootloader

--- a/src/usb/uf2/uf2cfg.h
+++ b/src/usb/uf2/uf2cfg.h
@@ -1,10 +1,10 @@
 #include "boards.h"
 #include "dfu_types.h"
 
-// Legacy Family ID for updating Application
+// Family ID for updating generic Application
 #define CFG_UF2_FAMILY_APP_ID     0xADA52840
 
-// Family ID for board-specific Application
+// Board-specific ID for board-specific Application
 #if defined(USB_DESC_VID) && defined(USB_DESC_UF2_PID) && USB_DESC_VID && USB_DESC_UF2_PID
     #define CFG_UF2_BOARD_APP_ID      ((USB_DESC_VID << 16) | USB_DESC_UF2_PID)
 #endif

--- a/src/usb/uf2/uf2cfg.h
+++ b/src/usb/uf2/uf2cfg.h
@@ -1,8 +1,11 @@
 #include "boards.h"
 #include "dfu_types.h"
 
-// Family ID for updating Application
+// Legacy Family ID for updating Application
 #define CFG_UF2_FAMILY_APP_ID     0xADA52840
+
+// Family ID for board-specific Application
+#define CFG_UF2_BOARD_APP_ID      ((USB_DESC_VID << 16) | USB_DESC_UF2_PID)
 
 // Family ID for updating Bootloader
 #define CFG_UF2_FAMILY_BOOT_ID    0xd663823c

--- a/src/usb/uf2/uf2cfg.h
+++ b/src/usb/uf2/uf2cfg.h
@@ -1,13 +1,15 @@
 #include "boards.h"
 #include "dfu_types.h"
 
-// Legacy Family ID for updating Application
-#define CFG_UF2_FAMILY_APP_ID     0xADA52840
-
-// Family ID for board-specific Application
-#if defined(USB_DESC_VID) && defined(USB_DESC_UF2_PID) && USB_DESC_VID && USB_DESC_UF2_PID
-    #define CFG_UF2_BOARD_APP_ID      ((USB_DESC_VID << 16) | USB_DESC_UF2_PID)
+#if !defined(USB_DESC_VID) || !defined(USB_DESC_UF2_PID) || !USB_DESC_VID || !USB_DESC_UF2_PID
+    #error "Per @hathach, 'This repo doesn't accept nrf52840/833 that doesn't have VID/PID'"
 #endif
+
+
+// Family ID for updating Application
+#define CFG_UF2_FAMILY_APP_ID     0xADA52840
+// Board ID for board-specific Application
+#define CFG_UF2_BOARD_APP_ID      ((USB_DESC_VID << 16) | USB_DESC_UF2_PID)
 
 
 // Family ID for updating Bootloader

--- a/src/usb/uf2/uf2cfg.h
+++ b/src/usb/uf2/uf2cfg.h
@@ -5,7 +5,10 @@
 #define CFG_UF2_FAMILY_APP_ID     0xADA52840
 
 // Family ID for board-specific Application
-#define CFG_UF2_BOARD_APP_ID      ((USB_DESC_VID << 16) | USB_DESC_UF2_PID)
+#if defined(USB_DESC_VID) && defined(USB_DESC_UF2_PID) && USB_DESC_VID && USB_DESC_UF2_PID
+    #define CFG_UF2_BOARD_APP_ID      ((USB_DESC_VID << 16) | USB_DESC_UF2_PID)
+#endif
+
 
 // Family ID for updating Bootloader
 #define CFG_UF2_FAMILY_BOOT_ID    0xd663823c


### PR DESCRIPTION
**_NOTE: REQUIRES TESTING_**  (will edit if changes)

Fix #130.

For boards that do not define both USB VID and PID, no change in behavior.  Otherwise...

* Accept UF2 blocks that have the USB VID/PID as the family ID, **_in addition to_** the "legacy" family id of `0xada52840`.

* When exposing the current user application, exposes it using the USB VID/PID as the family ID.