### PR TITLE
Add definable flag to skip app CRC check.

### DIFF
--- a/lib/sdk11/components/libraries/bootloader_dfu/bootloader.c
+++ b/lib/sdk11/components/libraries/bootloader_dfu/bootloader.c
@@ -160,7 +160,7 @@ bool bootloader_app_is_valid(void)
   {
     return false;
   }
-
+#if !defined(DISABLE_APPLICATION_CRC_CHECK)
   // The application in CODE region 1 is flagged as valid during update.
   if ( p_bootloader_settings->bank_0 == BANK_VALID_APP )
   {
@@ -176,6 +176,10 @@ bool bootloader_app_is_valid(void)
 
     success = (image_crc == p_bootloader_settings->bank_0_crc);
   }
+#else
+  // DISABLE_APPLICATION_CRC_CHECK was defined, assume CRC check passed.
+  success = true;
+#endif
 
   return success;
 }


### PR DESCRIPTION
If a board.mk defines a symbol named `DISABLE_APPLICATION_CRC_CHECK` (such as via `CFLAGS += -DDISABLE_APPLICATION_CRC_CHECK`), the code that would otherwise check for the application's CRC validity will not be compiled, and success will be assumed.

This would be an optional feature for users like in #115 that don't have CRC calculation (and setting) as part of their flash process.