### PR TITLE
Add pyocd flash targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,12 +47,11 @@ GDB     = $(CROSS_COMPILE)gdb
 # Flasher utility options
 NRFUTIL = adafruit-nrfutil
 NRFJPROG = nrfjprog
-FLASHER ?=
+FLASHER ?= nrfjprog
 
-# default to nrf
-ifeq ($(FLASHER),)
-  FLASHER = nrf
-else ifeq ($(FLASHER),pyocd)
+# Flasher will default to nrfjprog,
+# Check for pyocd, error on unexpected value.
+ifeq ($(FLASHER),pyocd)
   PYOCD ?= pyocd
 else
   $(error Unsupported flash utility: "$(FLASHER)")
@@ -398,8 +397,8 @@ __check_defined = \
     $(if $(value $1),, \
     $(error Undefined make flag: $1$(if $2, ($2))))
 
-#------------------- Flash with NRFUTIL -------------------
-ifeq ($(FLASHER),nrf)
+#------------------- Flash with NRFJPROG -------------------
+ifeq ($(FLASHER),nrfjprog)
 
 # Flash the compiled
 flash: $(BUILD)/$(OUT_FILE)-nosd.hex

--- a/Makefile
+++ b/Makefile
@@ -398,12 +398,11 @@ __check_defined = \
     $(if $(value $1),, \
     $(error Undefined make flag: $1$(if $2, ($2))))
 
-	
 #------------------- Flash with NRFUTIL -------------------
 ifeq ($(FLASHER),nrf)
 
-  # Flash the compiled
-  flash: $(BUILD)/$(OUT_FILE)-nosd.hex
+# Flash the compiled
+flash: $(BUILD)/$(OUT_FILE)-nosd.hex
 	@echo Flashing: $(notdir $<)
 	$(NRFJPROG) --program $< --sectoranduicrerase -f nrf52 --reset
 
@@ -412,25 +411,25 @@ ifeq ($(FLASHER),nrf)
 	@:$(call check_defined, SERIAL, example: SERIAL=/dev/ttyACM0)
 	$(NRFUTIL) --verbose dfu serial --package $< -p $(SERIAL) -b 115200 --singlebank --touch 1200
 
-  erase:
+erase:
 	@echo Erasing flash
 	$(NRFJPROG) -f nrf52 --eraseall
 
-  # flash SD only
-  sd:
+# flash SD only
+sd:
 	@echo Flashing: $(SD_HEX)
 	$(NRFJPROG) --program $(SD_HEX) -f nrf52 --sectorerase --reset
 
-  # flash MBR only
-  mbr:
+# flash MBR only
+mbr:
 	@echo Flashing: $(MBR_HEX)
 	$(NRFJPROG) --program $(MBR_HEX) -f nrf52 --sectorerase --reset
 
 #------------------- Flash with PYOCD -------------------
 else ifeq ($(FLASHER),pyocd)
 
-  # Flash the compiled
-  flash: $(BUILD)/$(OUT_FILE)-nosd.hex
+# Flash the compiled
+flash: $(BUILD)/$(OUT_FILE)-nosd.hex
 	@echo Flashing: $(notdir $<)
 	$(PYOCD) flash -t $(MCU_SUB_VARIANT) $<
 
@@ -442,13 +441,13 @@ else ifeq ($(FLASHER),pyocd)
 	@echo Erasing flash
 	$(PYOCD) erase -t $(MCU_SUB_VARIANT) --chip
 
-  # flash SD only
-  sd:
+# flash SD only
+sd:
 	@echo Flashing: $(SD_HEX)
 	$(PYOCD) flash -t $(MCU_SUB_VARIANT) $(SD_HEX)
 
-  # flash MBR only
-  mbr:
+# flash MBR only
+mbr:
 	@echo Flashing: $(MBR_HEX)
 	$(PYOCD) flash -t $(MCU_SUB_VARIANT) $(MBR_HEX)
 
@@ -457,7 +456,7 @@ endif
 #------------------- Debugging -------------------
 
 gdbflash: $(BUILD)/$(MERGED_FILE).hex
- 	@echo Flashing: $<
+	@echo Flashing: $<
 	@$(GDB_BMP) -nx --batch -ex 'load $<' -ex 'compare-sections' -ex 'kill'
 
 gdb: $(BUILD)/$(OUT_FILE).out

--- a/Makefile
+++ b/Makefile
@@ -405,11 +405,6 @@ flash: $(BUILD)/$(OUT_FILE)-nosd.hex
 	@echo Flashing: $(notdir $<)
 	$(NRFJPROG) --program $< --sectoranduicrerase -f nrf52 --reset
 
-  # dfu using CDC interface
-  dfu-flash: $(BUILD)/$(MERGED_FILE).zip
-	@:$(call check_defined, SERIAL, example: SERIAL=/dev/ttyACM0)
-	$(NRFUTIL) --verbose dfu serial --package $< -p $(SERIAL) -b 115200 --singlebank --touch 1200
-
 erase:
 	@echo Erasing flash
 	$(NRFJPROG) -f nrf52 --eraseall
@@ -432,11 +427,7 @@ flash: $(BUILD)/$(OUT_FILE)-nosd.hex
 	@echo Flashing: $(notdir $<)
 	$(PYOCD) flash -t $(MCU_SUB_VARIANT) $<
 
-  # dfu unsupported with pyocd
-  dfu-flash: $(BUILD)/$(MERGED_FILE).zip
-	$(error dfu-flash is not implemented with pyocd as the FLASHER)
-
-  erase:
+erase:
 	@echo Erasing flash
 	$(PYOCD) erase -t $(MCU_SUB_VARIANT) --chip
 
@@ -451,6 +442,13 @@ mbr:
 	$(PYOCD) flash -t $(MCU_SUB_VARIANT) $(MBR_HEX)
 
 endif
+
+#------------------- Flash with NRFUTIL via DFU -------------------
+
+# dfu using CDC interface
+dfu-flash: $(BUILD)/$(MERGED_FILE).zip
+	@:$(call check_defined, SERIAL, example: SERIAL=/dev/ttyACM0)
+	$(NRFUTIL) --verbose dfu serial --package $< -p $(SERIAL) -b 115200 --singlebank --touch 1200
 
 #------------------- Debugging -------------------
 

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,19 @@ OBJCOPY = $(CROSS_COMPILE)objcopy
 SIZE    = $(CROSS_COMPILE)size
 GDB     = $(CROSS_COMPILE)gdb
 
+# Flasher utility options
 NRFUTIL = adafruit-nrfutil
 NRFJPROG = nrfjprog
+FLASHER ?=
+
+# default to nrf
+ifeq ($(FLASHER),)
+  FLASHER = nrf
+else ifeq ($(FLASHER),pyocd)
+  PYOCD ?= pyocd
+else
+  $(error Unsupported flash utility: "$(FLASHER)")
+endif
 
 # Set make directory command, Windows tries to create a directory named "-p" if that flag is there.
 ifneq ($(OS), Windows_NT)
@@ -387,32 +398,66 @@ __check_defined = \
     $(if $(value $1),, \
     $(error Undefined make flag: $1$(if $2, ($2))))
 
-# Flash the compiled
-flash: $(BUILD)/$(OUT_FILE)-nosd.hex
+	
+#------------------- Flash with NRFUTIL -------------------
+ifeq ($(FLASHER),nrf)
+
+  # Flash the compiled
+  flash: $(BUILD)/$(OUT_FILE)-nosd.hex
 	@echo Flashing: $(notdir $<)
 	$(NRFJPROG) --program $< --sectoranduicrerase -f nrf52 --reset
 
-# dfu using CDC interface
-dfu-flash: $(BUILD)/$(MERGED_FILE).zip
+  # dfu using CDC interface
+  dfu-flash: $(BUILD)/$(MERGED_FILE).zip
 	@:$(call check_defined, SERIAL, example: SERIAL=/dev/ttyACM0)
 	$(NRFUTIL) --verbose dfu serial --package $< -p $(SERIAL) -b 115200 --singlebank --touch 1200
 
-erase:
+  erase:
 	@echo Erasing flash
 	$(NRFJPROG) -f nrf52 --eraseall
 
-# flash SD only
-sd:
+  # flash SD only
+  sd:
 	@echo Flashing: $(SD_HEX)
 	$(NRFJPROG) --program $(SD_HEX) -f nrf52 --sectorerase --reset
 
-# flash MBR only
-mbr:
+  # flash MBR only
+  mbr:
 	@echo Flashing: $(MBR_HEX)
 	$(NRFJPROG) --program $(MBR_HEX) -f nrf52 --sectorerase --reset
 
+#------------------- Flash with PYOCD -------------------
+else ifeq ($(FLASHER),pyocd)
+
+  # Flash the compiled
+  flash: $(BUILD)/$(OUT_FILE)-nosd.hex
+	@echo Flashing: $(notdir $<)
+	$(PYOCD) flash -t $(MCU_SUB_VARIANT) $<
+
+  # dfu unsupported with pyocd
+  dfu-flash: $(BUILD)/$(MERGED_FILE).zip
+	$(error dfu-flash is not implemented with pyocd as the FLASHER)
+
+  erase:
+	@echo Erasing flash
+	$(PYOCD) erase -t $(MCU_SUB_VARIANT) --chip
+
+  # flash SD only
+  sd:
+	@echo Flashing: $(SD_HEX)
+	$(PYOCD) flash -t $(MCU_SUB_VARIANT) $(SD_HEX)
+
+  # flash MBR only
+  mbr:
+	@echo Flashing: $(MBR_HEX)
+	$(PYOCD) flash -t $(MCU_SUB_VARIANT) $(MBR_HEX)
+
+endif
+
+#------------------- Debugging -------------------
+
 gdbflash: $(BUILD)/$(MERGED_FILE).hex
-	@echo Flashing: $<
+ 	@echo Flashing: $<
 	@$(GDB_BMP) -nx --batch -ex 'load $<' -ex 'compare-sections' -ex 'kill'
 
 gdb: $(BUILD)/$(OUT_FILE).out


### PR DESCRIPTION
They are used when make is invoked with FLASHER=pyocd. Still defaults to using NRFUTIL.