### PR TITLE
Resolve OTA failure with bond shared from application

### DIFF
--- a/lib/sdk11/components/libraries/bootloader_dfu/dfu_transport_ble.c
+++ b/lib/sdk11/components/libraries/bootloader_dfu/dfu_transport_ble.c
@@ -148,6 +148,7 @@ static uint32_t service_change_indicate()
 
         err_code = sd_ble_gatts_service_changed(m_conn_handle, DFU_SERVICE_HANDLE, BLE_HANDLE_MAX);
         if ((err_code == BLE_ERROR_INVALID_CONN_HANDLE) ||
+            (err_code == BLE_ERROR_INVALID_ATTR_HANDLE) ||
             (err_code == NRF_ERROR_INVALID_STATE) ||
             (err_code == NRF_ERROR_BUSY))
         {


### PR DESCRIPTION
Fixes #104 and allows for OTA DFU update with peers that are already bonded. 