### PR TITLE
Allow for power supply configuration

### DIFF
--- a/src/boards/boards.c
+++ b/src/boards/boards.c
@@ -82,6 +82,31 @@ void board_init(void)
   neopixel_init();
 #endif
 
+#if ENABLE_DCDC_0 == 1
+  NRF_POWER->DCDCEN0 = 1;
+#endif
+#if ENABLE_DCDC_1 == 1
+  NRF_POWER->DCDCEN = 1;
+#endif
+
+// When board is supplied on VDDH (and not VDD), this specifies what voltage the GPIO should run at
+// and what voltage is output at VDD. The default (0xffffffff) is 1.8V; typically you'll want
+//     #define UICR_REGOUT0_VALUE UICR_REGOUT0_VOUT_3V3
+// in board.h when using that power configuration.
+#ifdef UICR_REGOUT0_VALUE
+  if (NRF_UICR->REGOUT0 != UICR_REGOUT0_VALUE) 
+  {
+      NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+      while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+      NRF_UICR->REGOUT0 = UICR_REGOUT0_VALUE;
+
+      NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+      while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+
+      NVIC_SystemReset();
+  }
+#endif
+
   // Init scheduler
   APP_SCHED_INIT(SCHED_MAX_EVENT_DATA_SIZE, SCHED_QUEUE_SIZE);
 

--- a/src/boards/boards.h
+++ b/src/boards/boards.h
@@ -61,6 +61,14 @@
 #define BOARD_RGB_BRIGHTNESS 0x101010
 #endif
 
+// Power configuration - should we enable DC/DC converters? (requires inductors on board)
+#ifndef ENABLE_DCDC_0
+#define ENABLE_DCDC_0 0
+#endif
+#ifndef ENABLE_DCDC_1
+#define ENABLE_DCDC_1 0
+#endif
+
 // Helper function
 #define memclr(buffer, size)                memset(buffer, 0, size)
 #define varclr(_var)                        memclr(_var, sizeof(*(_var)))


### PR DESCRIPTION
In case the MCU is supplied through its own LDO or DCDC, it's useful to configure that from bootloader. Many boards don't have an inductor for the DCDC0, but at least some modules have one for DCDC1, so I made them independent. The power consumption is about 2x lower with DCDC compared to LDO.