### PR TITLE
fix against pollution of REGOUT0 reserved bits

### DIFF
--- a/src/boards/boards.c
+++ b/src/boards/boards.c
@@ -94,11 +94,13 @@ void board_init(void)
 //     #define UICR_REGOUT0_VALUE UICR_REGOUT0_VOUT_3V3
 // in board.h when using that power configuration.
 #ifdef UICR_REGOUT0_VALUE
-  if (NRF_UICR->REGOUT0 != UICR_REGOUT0_VALUE) 
+  if ((NRF_UICR->REGOUT0 & UICR_REGOUT0_VOUT_Msk) !=
+      (UICR_REGOUT0_VALUE << UICR_REGOUT0_VOUT_Pos))
   {
       NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
       while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
-      NRF_UICR->REGOUT0 = UICR_REGOUT0_VALUE;
+      NRF_UICR->REGOUT0 = (NRF_UICR->REGOUT0 & ~((uint32_t)UICR_REGOUT0_VOUT_Msk)) |
+                          (UICR_REGOUT0_VALUE << UICR_REGOUT0_VOUT_Pos);
 
       NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
       while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}


### PR DESCRIPTION
When UICR_REGOUT0_VALUE  macro is set to
```

#define UICR_REGOUT0_VALUE UICR_REGOUT0_VOUT_3V3

```
as suggested by author of https://github.com/adafruit/Adafruit_nRF52_Bootloader/pull/177 - the REGOUT0  new value becomes 0x00000005 instead of 0xFFFFFFFD.

This PR is intended to fix the issue.