### PR TITLE
Software reset

### DIFF
--- a/lib/sdk11/components/libraries/bootloader_dfu/bootloader.c
+++ b/lib/sdk11/components/libraries/bootloader_dfu/bootloader.c
@@ -115,6 +115,13 @@ static void wait_for_events(void)
 //    uint32_t err_code = sd_app_evt_wait();
 //    APP_ERROR_CHECK(err_code);
 
+#ifdef SOFTWARE_RESET_BUTTON
+    if (button_pressed(SOFTWARE_RESET_BUTTON)) {
+        while(button_pressed(SOFTWARE_RESET_BUTTON)) { NRFX_DELAY_MS(10); }
+        NVIC_SystemReset();
+    }
+#endif
+
     // Feed all Watchdog just in case application enable it
     // WDT cannot be disabled once started. It even last through NVIC soft reset
     if ( nrf_wdt_started(NRF_WDT) )

--- a/src/boards/boards.c
+++ b/src/boards/boards.c
@@ -73,6 +73,9 @@ void board_init(void)
 
   button_init(BUTTON_DFU);
   button_init(BUTTON_FRESET);
+#ifdef SOFTWARE_RESET_BUTTON
+  button_init(SOFTWARE_RESET_BUTTON);
+#endif
   NRFX_DELAY_US(100); // wait for the pin state is stable
 
 #if LEDS_NUMBER > 0


### PR DESCRIPTION
This PR adds the capability for any pin to be used as a software reset pin. This allows users to jump to an existing app with a single button press.

Depends on #192 