### PR TITLE
Add board 'sparkfun_nrf52840_micromod'.

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -45,6 +45,7 @@ jobs:
           - 'pca10100'
           - 'pitaya_go'
           - 'raytac_mdbt50q_rx'
+          - 'sparkfun_nrf52840_micromod'
           - 'waveshare_nrf52840_eval'
 
     steps:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This is a CDC/DFU/UF2 bootloader for nRF52 boards.
 - Particle Argon
 - Particle Boron
 - Particle Xenon
+- [SparkFun MicroMod nRF52840](https://www.sparkfun.com/products/16984)
 
 UF2 is an easy-to-use bootloader that appears as a flash drive. You can just copy `.uf2`-format
 application images to the flash drive to load new firmware. See https://github.com/Microsoft/uf2 and https://github.com/adafruit/uf2-samdx1 for more information.

--- a/src/boards/sparkfun_nrf52840_micromod/board.h
+++ b/src/boards/sparkfun_nrf52840_micromod/board.h
@@ -59,7 +59,7 @@
 //------------- UF2 -------------//
 #define UF2_PRODUCT_NAME       "SparkFun MicroMod nRF52840"
 #define UF2_VOLUME_LABEL       "SFMM852BOOT"
-#define UF2_BOARD_ID           "micromod-nRF52840"
+#define UF2_BOARD_ID           "nRF52840-micromod-v10"
 
 #define UF2_INDEX_URL          "https://www.sparkfun.com/products/16984"
 

--- a/src/boards/sparkfun_nrf52840_micromod/board.h
+++ b/src/boards/sparkfun_nrf52840_micromod/board.h
@@ -1,0 +1,66 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ha Thach for Adafruit Industries
+ * Copyright (c) 2021 Chris Marc Dailey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef _SPARKFUN_NRF52840_MICROMOD_H_
+#define _SPARKFUN_NRF52840_MICROMOD_H_
+
+#define _PINNUM(port, pin)    ((port)*32 + (pin))
+
+/*------------------------------------------------------------------*/
+/* LED
+ *------------------------------------------------------------------*/
+#define LEDS_NUMBER           1
+#define LED_PRIMARY_PIN       _PINNUM(0, 13)
+#define LED_STATE_ON          1
+
+/*------------------------------------------------------------------*/
+/* BUTTON
+ *------------------------------------------------------------------*/
+#define BUTTONS_NUMBER        2
+#define BUTTON_1              _PINNUM(0, 7)
+#define BUTTON_2              _PINNUM(0, 10)
+#define BUTTON_PULL           NRF_GPIO_PIN_PULLUP
+
+//--------------------------------------------------------------------+
+// BLE OTA
+//--------------------------------------------------------------------+
+#define BLEDIS_MANUFACTURER   "SparkFun"
+#define BLEDIS_MODEL          "MicroMod nRF52840"
+
+//--------------------------------------------------------------------+
+// USB
+//--------------------------------------------------------------------+
+#define USB_DESC_VID           0x1B4F
+#define USB_DESC_UF2_PID       0x0001
+#define USB_DESC_CDC_ONLY_PID  0x0002
+
+//------------- UF2 -------------//
+#define UF2_PRODUCT_NAME       "SparkFun MicroMod nRF52840"
+#define UF2_VOLUME_LABEL       "SFMM852BOOT"
+#define UF2_BOARD_ID           "micromod-nRF52840"
+
+#define UF2_INDEX_URL          "https://www.sparkfun.com/products/16984"
+
+#endif /* _SPARKFUN_NRF52840_MICROMOD_H_ */

--- a/src/boards/sparkfun_nrf52840_micromod/board.h
+++ b/src/boards/sparkfun_nrf52840_micromod/board.h
@@ -53,8 +53,8 @@
 // USB
 //--------------------------------------------------------------------+
 #define USB_DESC_VID           0x1B4F
-#define USB_DESC_UF2_PID       0x0001
-#define USB_DESC_CDC_ONLY_PID  0x0002
+#define USB_DESC_UF2_PID       0x0022
+#define USB_DESC_CDC_ONLY_PID  0x0023
 
 //------------- UF2 -------------//
 #define UF2_PRODUCT_NAME       "SparkFun MicroMod nRF52840"

--- a/src/boards/sparkfun_nrf52840_micromod/board.mk
+++ b/src/boards/sparkfun_nrf52840_micromod/board.mk
@@ -1,0 +1,1 @@
+MCU_SUB_VARIANT = nrf52840

--- a/src/boards/sparkfun_nrf52840_micromod/pinconfig.c
+++ b/src/boards/sparkfun_nrf52840_micromod/pinconfig.c
@@ -1,0 +1,19 @@
+#include "boards.h"
+#include "uf2/configkeys.h"
+
+__attribute__((used, section(".bootloaderConfig")))
+const uint32_t bootloaderConfig[] =
+{
+  /* CF2 START */
+  CFG_MAGIC0, CFG_MAGIC1,                       // magic
+  5, 100,                                       // used entries, total entries
+
+  204, 0x100000,                                // FLASH_BYTES = 0x100000
+  205, 0x40000,                                 // RAM_BYTES = 0x40000
+  208, (USB_DESC_VID << 16) | USB_DESC_UF2_PID, // BOOTLOADER_BOARD_ID = USB VID+PID, used for verification when updating bootloader via uf2
+  209, 0xada52840,                              // UF2_FAMILY = 0xada52840
+  210, 0x20,                                    // PINS_PORT_SIZE = PA_32
+
+  0, 0, 0, 0, 0, 0, 0, 0
+  /* CF2 END */
+};


### PR DESCRIPTION
Hey there!

Added the [SparkFun MicroMod nRF52840](https://www.sparkfun.com/products/16984). Opening the PR as a draft, because I don't have a PID to use. Gonna try to get in touch with someone from SparkFun and see if they've got some PIDs they'd like to use for UF2 & CircuitPython.

Hope you're well!