### PR TITLE
adding support for generic nrf52833 board

### DIFF
--- a/src/boards/generic_nrf52833/board.h
+++ b/src/boards/generic_nrf52833/board.h
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ha Thach for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef GENERIC_NRF52833_H
+#define GENERIC_NRF52833_H
+
+/*------------------------------------------------------------------*/
+/* LED
+ *------------------------------------------------------------------*/
+#define LEDS_NUMBER         1
+#define LED_PRIMARY_PIN     39
+#define LED_STATE_ON        0   // lit on low
+
+/*------------------------------------------------------------------*/
+/* BUTTON
+ *------------------------------------------------------------------*/
+#define BUTTONS_NUMBER      2
+#define BUTTON_1            36  // DFU
+#define BUTTON_2            38  // FRESET
+#define BUTTON_PULL         NRF_GPIO_PIN_PULLUP
+
+//--------------------------------------------------------------------+
+// BLE OTA
+//--------------------------------------------------------------------+
+#define BLEDIS_MANUFACTURER    "Generic"
+#define BLEDIS_MODEL           "NRF52833"
+
+//--------------------------------------------------------------------+
+// USB
+//--------------------------------------------------------------------+
+#define USB_DESC_VID           0x1915
+#define USB_DESC_UF2_PID       0x521F
+#define USB_DESC_CDC_ONLY_PID  0x521F
+
+#define UF2_PRODUCT_NAME    "Generic nrf52833"
+#define UF2_BOARD_ID        "generic-nRF52833"
+#define UF2_INDEX_URL       "http://nordicsemi.com"
+
+#endif // GENERIC_NRF52833_H

--- a/src/boards/generic_nrf52833/board.mk
+++ b/src/boards/generic_nrf52833/board.mk
@@ -1,0 +1,1 @@
+MCU_SUB_VARIANT = nrf52833

--- a/src/boards/generic_nrf52833/pinconfig.c
+++ b/src/boards/generic_nrf52833/pinconfig.c
@@ -1,0 +1,19 @@
+#include "boards.h"
+#include "uf2/configkeys.h"
+
+__attribute__((used, section(".bootloaderConfig")))
+const uint32_t bootloaderConfig[] =
+{
+  /* CF2 START */
+  CFG_MAGIC0, CFG_MAGIC1,                       // magic
+  5, 100,                                       // used entries, total entries
+
+  204, 0x800000,                                // FLASH_BYTES = 0x100000
+  205, 0x20000,                                 // RAM_BYTES = 0x40000
+  208, (USB_DESC_VID << 16) | USB_DESC_UF2_PID, // BOOTLOADER_BOARD_ID = USB VID+PID, used for verification when updating bootloader via uf2
+  209, 0xada52840,                              // UF2_FAMILY = 0xada52840
+  210, 0x20,                                    // PINS_PORT_SIZE = PA_32
+
+  0, 0, 0, 0, 0, 0, 0, 0
+  /* CF2 END */
+};

--- a/src/usb/uf2/uf2cfg.h
+++ b/src/usb/uf2/uf2cfg.h
@@ -14,11 +14,19 @@
 #define CFG_UF2_FAMILY_BOOT_ID    0xd663823c
 
 #define CFG_UF2_NUM_BLOCKS        0x10109     // just under 32MB
-#define CFG_UF2_FLASH_SIZE        (1024*1024) // 1 MB
+#if defined(NRF52833_XXAA)
+    #define CFG_UF2_FLASH_SIZE        0x80000 // 512 kB
+#else
+    #define CFG_UF2_FLASH_SIZE        (1024*1024) // 1 MB
+#endif
 
 // Application Address Space
 #define USER_FLASH_START          MBR_SIZE // skip MBR included in SD hex
-#define USER_FLASH_END            0xAD000
+#if defined(NRF52833_XXAA)
+    #define USER_FLASH_END            0x2D000
+#else
+    #define USER_FLASH_END            0xAD000
+#endif
 
 // Bootloader start address
 #define BOOTLOADER_ADDR_START         BOOTLOADER_REGION_START


### PR DESCRIPTION
I had a need to get this working on a custom nrf52833 board and wanted to share the result. I don't have a pca10100 to test with but could get one if it would prove useful in validating this pull request. Otherwise I added a 'generic nrf52833'.

I wasn't sure what to put for usb vendor and product ids so please do let me know if those should be changed.