### PR TITLE
Adding EByte E104-BT5032A module

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -32,6 +32,7 @@ jobs:
           - 'arduino_nano_33_ble'
           - 'bast_ble'
           - 'bluemicro_nrf52840'
+          - 'ebyte_e104_bt5032a'
           - 'electronut_labs_papyr'
           - 'ikigaisense_vita'
           - 'mdk_nrf52840_dongle'

--- a/src/boards/ebyte_e104_bt5032a/board.h
+++ b/src/boards/ebyte_e104_bt5032a/board.h
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Pierre Constantineau
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef _EBYTE_E104_BT5032A_H
+#define _EBYTE_E104_BT5032A_H
+
+/*------------------------------------------------------------------*/
+/* LED
+ *------------------------------------------------------------------*/
+#define LEDS_NUMBER        2
+#define LED_PRIMARY_PIN    31 // Red  - named "Data"
+#define LED_SECONDARY_PIN  30 // Blue - named "Link" (actually a red one...)
+#define LED_STATE_ON       1
+
+/*------------------------------------------------------------------*/
+/* BUTTON
+ *------------------------------------------------------------------*/
+#define BUTTONS_NUMBER     1
+#define BUTTON_1           29 // Actual Button - DISC
+#define BUTTON_2           28 // No button - WKP pin
+#define BUTTON_PULL        NRF_GPIO_PIN_PULLUP
+
+/*------------------------------------------------------------------*/
+/* UART (only used by nRF52832)
+ *------------------------------------------------------------------*/
+#define RX_PIN_NUMBER      14
+#define TX_PIN_NUMBER      18
+#define CTS_PIN_NUMBER     20
+#define RTS_PIN_NUMBER     19
+#define HWFC               false  // leaving it false to make GPIO available
+
+//--------------------------------------------------------------------+
+// BLE OTA
+//--------------------------------------------------------------------+
+#define BLEDIS_MANUFACTURER "CDEBYTE"
+#define BLEDIS_MODEL        "E104-BT5032A"
+
+#define UF2_PRODUCT_NAME    "Ebyte E104-BT5032A nRF52832"
+#define UF2_INDEX_URL       "https://www.ebyte.com/en/product-view-news.html?id=756"
+
+#endif // _EBYTE_E104_BT5032A_H

--- a/src/boards/ebyte_e104_bt5032a/board.h
+++ b/src/boards/ebyte_e104_bt5032a/board.h
@@ -30,14 +30,18 @@
  *------------------------------------------------------------------*/
 #define LEDS_NUMBER        2
 #define LED_PRIMARY_PIN    31 // Red  - named "Data"
-#define LED_SECONDARY_PIN  30 // Blue - named "Link" (actually a red one...)
+#define LED_SECONDARY_PIN  30 // Blue - named "Link" (also a red one on the Test Board)
 #define LED_STATE_ON       1
 
 /*------------------------------------------------------------------*/
 /* BUTTON
  *------------------------------------------------------------------*/
 #define BUTTONS_NUMBER     2
-#define BUTTON_1           29 // Actual Button - DISC
+#define BUTTON_1           29 // DISC Button on E104-BT5032A-TB Test Board
+                              // BUTTON_1 is DFU.  The module does not have reset circuitry.
+                              // The Test Board from Ebyte (E104-BT5032A-TB) also does not have reset circuitry
+                              // To be able to upload using the Arduino IDE, (To enter DFU mode)
+                              // Press "DISC", press and release "RST", then release "DISC"
 #define BUTTON_2           28 // No button - WKP pin
 #define BUTTON_PULL        NRF_GPIO_PIN_PULLUP
 

--- a/src/boards/ebyte_e104_bt5032a/board.h
+++ b/src/boards/ebyte_e104_bt5032a/board.h
@@ -36,7 +36,7 @@
 /*------------------------------------------------------------------*/
 /* BUTTON
  *------------------------------------------------------------------*/
-#define BUTTONS_NUMBER     1
+#define BUTTONS_NUMBER     2
 #define BUTTON_1           29 // Actual Button - DISC
 #define BUTTON_2           28 // No button - WKP pin
 #define BUTTON_PULL        NRF_GPIO_PIN_PULLUP

--- a/src/boards/ebyte_e104_bt5032a/board.mk
+++ b/src/boards/ebyte_e104_bt5032a/board.mk
@@ -1,0 +1,2 @@
+# nrf52 is nrf52832
+MCU_SUB_VARIANT = nrf52


### PR DESCRIPTION
This will allow to re-use the "Serial-AT" module and be able to reprogram it.