### PR TITLE
Add makerdiary m60 keyboard (uses nrf52840_m2)

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -36,6 +36,7 @@ jobs:
           - 'ebyte_e73_tbb'
           - 'electronut_labs_papyr'
           - 'ikigaisense_vita'
+          - 'm60_keyboard'
           - 'mdk_nrf52840_dongle'
           - 'nice_nano'
           - 'nrf52840_m2'

--- a/src/boards/m60_keyboard/board.h
+++ b/src/boards/m60_keyboard/board.h
@@ -1,0 +1,71 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Yihui Xiong for Makerdiary
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef _MAKERDIARY_M60_KEYBOARD_H_
+#define _MAKERDIARY_M60_KEYBOARD_H_
+
+#define _PINNUM(port, pin)    ((port)*32 + (pin))
+
+/*------------------------------------------------------------------*/
+/* LED
+ *------------------------------------------------------------------*/
+#define LEDS_NUMBER           1
+#define LED_PRIMARY_PIN       _PINNUM(0, 30)  // Red
+#define LED_STATE_ON          0
+
+#define LED_RGB_RED_PIN       _PINNUM(0, 30)
+#define LED_RGB_GREEN_PIN     _PINNUM(0, 29)
+#define LED_RGB_BLUE_PIN      _PINNUM(0, 31)
+#define BOARD_RGB_BRIGHTNESS  0x404040
+/*------------------------------------------------------------------*/
+/* BUTTON
+ *------------------------------------------------------------------*/
+#define BUTTONS_NUMBER        2
+#define BUTTON_1              _PINNUM(0, 27)
+#define BUTTON_2              _PINNUM(1, 7)
+#define BUTTON_PULL           NRF_GPIO_PIN_PULLUP
+
+//--------------------------------------------------------------------+
+// BLE OTA
+//--------------------------------------------------------------------+
+#define BLEDIS_MANUFACTURER   "Makerdiary"
+#define BLEDIS_MODEL          "M60 Mechanical Keyboard"
+
+//--------------------------------------------------------------------+
+// USB
+//--------------------------------------------------------------------+
+#define USB_DESC_VID            0x2886
+#define USB_DESC_UF2_PID        0xF00F
+#define USB_DESC_CDC_ONLY_PID   0xF00F
+
+//--------------------------------------------------------------------+
+// UF2
+//--------------------------------------------------------------------+
+#define UF2_PRODUCT_NAME        "MakerDiary M60 Mechanical Keyboard"
+#define UF2_VOLUME_LABEL        "M60KEYBOARD"
+#define UF2_BOARD_ID            "M60KEYBOARD"
+#define UF2_INDEX_URL           "https://wiki.makerdiary.com/m60/"
+
+
+#endif /* _MAKERDIARY_M60_KEYBOARD_H_ */

--- a/src/boards/m60_keyboard/board.mk
+++ b/src/boards/m60_keyboard/board.mk
@@ -1,0 +1,2 @@
+MCU_SUB_VARIANT = nrf52840
+USE_NFCT = yes

--- a/src/boards/m60_keyboard/pinconfig.c
+++ b/src/boards/m60_keyboard/pinconfig.c
@@ -1,0 +1,19 @@
+#include "boards.h"
+#include "uf2/configkeys.h"
+
+__attribute__((used, section(".bootloaderConfig")))
+const uint32_t bootloaderConfig[] =
+{
+  /* CF2 START */
+  CFG_MAGIC0, CFG_MAGIC1,                       // magic
+  5, 100,                                       // used entries, total entries
+
+  204, 0x100000,                                // FLASH_BYTES = 0x100000
+  205, 0x40000,                                 // RAM_BYTES = 0x40000
+  208, (USB_DESC_VID << 16) | USB_DESC_UF2_PID, // BOOTLOADER_BOARD_ID = USB VID+PID, used for verification when updating bootloader via uf2
+  209, 0xada52840,                              // UF2_FAMILY = 0xada52840
+  210, 0x20,                                    // PINS_PORT_SIZE = PA_32
+
+  0, 0, 0, 0, 0, 0, 0, 0
+  /* CF2 END */
+};


### PR DESCRIPTION
This PR adds the [Makerdiary M60 Mechanical Keyboard](https://wiki.makerdiary.com/m60/). The keyboard uses the Makerdiary nRF52840 M.2 module. 
I've been using this keyboard for a while with the nrf52840_m2 bootloader. It worked, but there was no way to get into bootloader mode via button, because the buttons defined are for the Makerdiary M.2 Developer Kit. The keyboard has only one button on pin 0_27, the second defined button is the one from nrf52840_m2. I tested the bootloader and I'm able to access bootloader mode via the button on the back now.
I'm not sure what i should use for the PID or VID, for now these are the ones from nrf52840_m2.