### PR TITLE
GCC 11 Build fixes

### DIFF
--- a/lib/sdk11/components/ble/ble_services/ble_dfu/ble_dfu.c
+++ b/lib/sdk11/components/ble/ble_services/ble_dfu/ble_dfu.c
@@ -463,7 +463,7 @@ uint32_t ble_dfu_init(ble_dfu_t * p_dfu, ble_dfu_init_t * p_dfu_init)
 
     p_dfu->conn_handle = BLE_CONN_HANDLE_INVALID;
 
-    ble_uuid_t service_uuid;
+    ble_uuid_t service_uuid = {0};
     uint32_t   err_code;
 
     const ble_uuid128_t base_uuid128 =

--- a/src/main.c
+++ b/src/main.c
@@ -416,7 +416,7 @@ uint32_t proc_ble(void)
 
   // Init header
   ble_evt_t* evt = (ble_evt_t*) ev_buf;
-  evt->header.evt_id = 0;
+  evt->header.evt_id = BLE_EVT_INVALID;
 
   // Get BLE Event
   uint32_t err = sd_ble_evt_get(ev_buf, &ev_len);

--- a/src/main.c
+++ b/src/main.c
@@ -411,7 +411,7 @@ void assert_nrf_callback (uint16_t line_num, uint8_t const * p_file_name)
 // Process BLE event from SD
 uint32_t proc_ble(void)
 {
-  __ALIGN(4) uint8_t ev_buf[ BLE_EVT_LEN_MAX(BLEGATT_ATT_MTU_MAX) ];
+  __ALIGN(4) uint8_t ev_buf[ BLE_EVT_LEN_MAX(BLEGATT_ATT_MTU_MAX) ] = {0};
   uint16_t ev_len = BLE_EVT_LEN_MAX(BLEGATT_ATT_MTU_MAX);
 
   // Get BLE Event
@@ -448,7 +448,7 @@ uint32_t proc_ble(void)
 // process SOC event from SD
 uint32_t proc_soc(void)
 {
-  uint32_t soc_evt;
+  uint32_t soc_evt = 0;
   uint32_t err = sd_evt_get(&soc_evt);
 
   if (NRF_SUCCESS == err)

--- a/src/main.c
+++ b/src/main.c
@@ -411,8 +411,12 @@ void assert_nrf_callback (uint16_t line_num, uint8_t const * p_file_name)
 // Process BLE event from SD
 uint32_t proc_ble(void)
 {
-  __ALIGN(4) uint8_t ev_buf[ BLE_EVT_LEN_MAX(BLEGATT_ATT_MTU_MAX) ] = {0};
+  __ALIGN(4) uint8_t ev_buf[ BLE_EVT_LEN_MAX(BLEGATT_ATT_MTU_MAX) ];
   uint16_t ev_len = BLE_EVT_LEN_MAX(BLEGATT_ATT_MTU_MAX);
+
+  // Init header
+  ble_evt_t* evt = (ble_evt_t*) ev_buf;
+  evt->header.evt_id = 0;
 
   // Get BLE Event
   uint32_t err = sd_ble_evt_get(ev_buf, &ev_len);
@@ -420,8 +424,6 @@ uint32_t proc_ble(void)
   // Handle valid event, ignore error
   if( NRF_SUCCESS == err)
   {
-    ble_evt_t* evt = (ble_evt_t*) ev_buf;
-
     switch (evt->header.evt_id)
     {
       case BLE_GAP_EVT_CONNECTED:


### PR DESCRIPTION
Fixed build errors for GCC11

``` c
src/main.c:456:5: error: 'soc_evt' may be used uninitialized [-Werror=maybe-uninitialized]
  456 |     pstorage_sys_event_handler(soc_evt);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/main.c: In function 'proc_ble':
src/main.c:425:24: error: '*(ble_evt_t *)(&ev_buf[0]).header.evt_id' may be used uninitialized [-Werror=maybe-uninitialized]
  425 |     switch (evt->header.evt_id)
      |             ~~~~~~~~~~~^~~~~~~

lib/sdk11/components/ble/ble_services/ble_dfu/ble_dfu.c: In function 'ble_dfu_init':
lib/sdk11/components/ble/ble_services/ble_dfu/ble_dfu.c:487:36: error: 'service_uuid.type' may be used uninitialized [-Werror=maybe-uninitialized]
  487 |     p_dfu->uuid_type = service_uuid.type;
      |                        ~~~~~~~~~~~~^~~~~
```      
