### PR TITLE
Fix flash with more than 512kb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,14 +104,17 @@ ifeq ($(MCU_SUB_VARIANT),nrf52)
   SD_NAME = s132
   DFU_DEV_REV = 0xADAF
   CFLAGS += -DNRF52 -DNRF52832_XXAA -DS132
+  CFLAGS += -DDFU_APP_DATA_RESERVED=7*4096
 else ifeq ($(MCU_SUB_VARIANT),nrf52833)
   SD_NAME = s140
   DFU_DEV_REV = 52840
   CFLAGS += -DNRF52833_XXAA -DS140
+  CFLAGS += -DDFU_APP_DATA_RESERVED=7*4096
 else ifeq ($(MCU_SUB_VARIANT),nrf52840)
   SD_NAME = s140
   DFU_DEV_REV = 52840
   CFLAGS += -DNRF52840_XXAA -DS140
+  CFLAGS += -DDFU_APP_DATA_RESERVED=10*4096
 else
   $(error Sub Variant $(MCU_SUB_VARIANT) is unknown)
 endif
@@ -232,15 +235,6 @@ IPATH += $(SD_PATH)/$(SD_FILENAME)_API/include/nrf52
 # Compiler Flags
 #------------------------------------------------------------------------------
 
-# Debug option use RTT for printf
-ifeq ($(DEBUG), 1)
-	RTT_SRC = lib/SEGGER_RTT
-	
-	CFLAGS += -DCFG_DEBUG -DSEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL
-	IPATH += $(RTT_SRC)/RTT
-  C_SRC += $(RTT_SRC)/RTT/SEGGER_RTT.c
-endif
-
 #flags common to all targets
 CFLAGS += \
 	-mthumb \
@@ -286,13 +280,20 @@ ifneq ($(USE_NFCT),yes)
 endif
 
 CFLAGS += -DSOFTDEVICE_PRESENT
-CFLAGS += -DDFU_APP_DATA_RESERVED=7*4096
-
 CFLAGS += -DUF2_VERSION='"$(GIT_VERSION) $(GIT_SUBMODULE_VERSIONS)"'
 CFLAGS += -DBLEDIS_FW_VERSION='"$(GIT_VERSION) $(SD_NAME) $(SD_VERSION)"'
 
 _VER = $(subst ., ,$(word 1, $(subst -, ,$(GIT_VERSION))))
 CFLAGS += -DMK_BOOTLOADER_VERSION='($(word 1,$(_VER)) << 16) + ($(word 2,$(_VER)) << 8) + $(word 3,$(_VER))'
+
+# Debug option use RTT for printf
+ifeq ($(DEBUG), 1)
+	RTT_SRC = lib/SEGGER_RTT
+	
+	CFLAGS += -DCFG_DEBUG -DCFG_TUSB_DEBUG=1 -DSEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL
+	IPATH += $(RTT_SRC)/RTT
+  C_SRC += $(RTT_SRC)/RTT/SEGGER_RTT.c
+endif
 
 #------------------------------------------------------------------------------
 # Linker Flags

--- a/lib/sdk11/components/libraries/bootloader_dfu/bootloader.c
+++ b/lib/sdk11/components/libraries/bootloader_dfu/bootloader.c
@@ -207,153 +207,151 @@ void bootloader_dfu_update_process(dfu_update_status_t update_status)
   __attribute__((aligned(4)))  static bootloader_settings_t settings;
   bootloader_settings_t const * p_bootloader_settings;
 
-    bootloader_util_settings_get(&p_bootloader_settings);
+  bootloader_util_settings_get(&p_bootloader_settings);
 
-    if (update_status.status_code == DFU_UPDATE_APP_COMPLETE)
+  if (update_status.status_code == DFU_UPDATE_APP_COMPLETE)
+  {
+    settings.bank_0_crc  = update_status.app_crc;
+    settings.bank_0_size = update_status.app_size;
+    settings.bank_0      = BANK_VALID_APP;
+    settings.bank_1      = BANK_INVALID_APP;
+
+    m_update_status      = BOOTLOADER_SETTINGS_SAVING;
+    bootloader_settings_save(&settings);
+  }
+  else if (update_status.status_code == DFU_UPDATE_SD_COMPLETE)
+  {
+    settings.bank_0_crc     = update_status.app_crc;
+    settings.bank_0_size    = update_status.sd_size + update_status.bl_size + update_status.app_size;
+    settings.bank_0         = BANK_VALID_SD;
+    settings.bank_1         = BANK_INVALID_APP;
+    settings.sd_image_size  = update_status.sd_size;
+    settings.bl_image_size  = update_status.bl_size;
+    settings.app_image_size = update_status.app_size;
+    settings.sd_image_start = update_status.sd_image_start;
+
+    m_update_status         = BOOTLOADER_SETTINGS_SAVING;
+    bootloader_settings_save(&settings);
+  }
+  else if (update_status.status_code == DFU_UPDATE_BOOT_COMPLETE)
+  {
+    settings.bank_0         = p_bootloader_settings->bank_0;
+    settings.bank_0_crc     = p_bootloader_settings->bank_0_crc;
+    settings.bank_0_size    = p_bootloader_settings->bank_0_size;
+    settings.bank_1         = BANK_VALID_BOOT;
+    settings.sd_image_size  = update_status.sd_size;
+    settings.bl_image_size  = update_status.bl_size;
+    settings.app_image_size = update_status.app_size;
+
+    m_update_status         = BOOTLOADER_SETTINGS_SAVING;
+    bootloader_settings_save(&settings);
+  }
+  else if (update_status.status_code == DFU_UPDATE_SD_SWAPPED)
+  {
+    if (p_bootloader_settings->bank_0 == BANK_VALID_SD)
     {
-        settings.bank_0_crc  = update_status.app_crc;
-        settings.bank_0_size = update_status.app_size;
-        settings.bank_0      = BANK_VALID_APP;
-        settings.bank_1      = BANK_INVALID_APP;
-
-        m_update_status      = BOOTLOADER_SETTINGS_SAVING;
-        bootloader_settings_save(&settings);
+      settings.bank_0_crc     = 0;
+      settings.bank_0_size    = 0;
+      settings.bank_0         = BANK_INVALID_APP;
     }
-    else if (update_status.status_code == DFU_UPDATE_SD_COMPLETE)
-    {
-        settings.bank_0_crc     = update_status.app_crc;
-        settings.bank_0_size    = update_status.sd_size +
-                                  update_status.bl_size +
-                                  update_status.app_size;
-        settings.bank_0         = BANK_VALID_SD;
-        settings.bank_1         = BANK_INVALID_APP;
-        settings.sd_image_size  = update_status.sd_size;
-        settings.bl_image_size  = update_status.bl_size;
-        settings.app_image_size = update_status.app_size;
-        settings.sd_image_start = update_status.sd_image_start;
-
-        m_update_status         = BOOTLOADER_SETTINGS_SAVING;
-        bootloader_settings_save(&settings);
-    }
-    else if (update_status.status_code == DFU_UPDATE_BOOT_COMPLETE)
-    {
-        settings.bank_0         = p_bootloader_settings->bank_0;
-        settings.bank_0_crc     = p_bootloader_settings->bank_0_crc;
-        settings.bank_0_size    = p_bootloader_settings->bank_0_size;
-        settings.bank_1         = BANK_VALID_BOOT;
-        settings.sd_image_size  = update_status.sd_size;
-        settings.bl_image_size  = update_status.bl_size;
-        settings.app_image_size = update_status.app_size;
-
-        m_update_status         = BOOTLOADER_SETTINGS_SAVING;
-        bootloader_settings_save(&settings);
-    }
-    else if (update_status.status_code == DFU_UPDATE_SD_SWAPPED)
-    {
-        if (p_bootloader_settings->bank_0 == BANK_VALID_SD)
-        {
-            settings.bank_0_crc     = 0;
-            settings.bank_0_size    = 0;
-            settings.bank_0         = BANK_INVALID_APP;
-        }
-        // This handles cases where SoftDevice was not updated, hence bank0 keeps its settings.
-        else
-        {
-            settings.bank_0         = p_bootloader_settings->bank_0;
-            settings.bank_0_crc     = p_bootloader_settings->bank_0_crc;
-            settings.bank_0_size    = p_bootloader_settings->bank_0_size;
-        }
-
-        settings.bank_1         = BANK_INVALID_APP;
-        settings.sd_image_size  = 0;
-        settings.bl_image_size  = 0;
-        settings.app_image_size = 0;
-
-        m_update_status         = BOOTLOADER_SETTINGS_SAVING;
-        bootloader_settings_save(&settings);
-    }
-    else if (update_status.status_code == DFU_TIMEOUT)
-    {
-        // Timeout has occurred. Close the connection with the DFU Controller.
-        uint32_t err_code;
-        if ( is_ota() )
-        {
-          err_code = dfu_transport_ble_close();
-        }else
-        {
-          err_code = dfu_transport_serial_close();
-        }
-        APP_ERROR_CHECK(err_code);
-
-        m_update_status = BOOTLOADER_TIMEOUT;
-    }
-    else if (update_status.status_code == DFU_BANK_0_ERASED)
-    {
-        settings.bank_0_crc  = 0;
-        settings.bank_0_size = 0;
-        settings.bank_0      = BANK_INVALID_APP;
-        settings.bank_1      = p_bootloader_settings->bank_1;
-
-        bootloader_settings_save(&settings);
-    }
-    else if (update_status.status_code == DFU_RESET)
-    {
-        m_update_status = BOOTLOADER_RESET;
-    }
+    // This handles cases where SoftDevice was not updated, hence bank0 keeps its settings.
     else
     {
-        // No implementation needed.
+      settings.bank_0         = p_bootloader_settings->bank_0;
+      settings.bank_0_crc     = p_bootloader_settings->bank_0_crc;
+      settings.bank_0_size    = p_bootloader_settings->bank_0_size;
     }
+
+    settings.bank_1         = BANK_INVALID_APP;
+    settings.sd_image_size  = 0;
+    settings.bl_image_size  = 0;
+    settings.app_image_size = 0;
+
+    m_update_status         = BOOTLOADER_SETTINGS_SAVING;
+    bootloader_settings_save(&settings);
+  }
+  else if (update_status.status_code == DFU_TIMEOUT)
+  {
+    // Timeout has occurred. Close the connection with the DFU Controller.
+    uint32_t err_code;
+    if ( is_ota() )
+    {
+      err_code = dfu_transport_ble_close();
+    }else
+    {
+      err_code = dfu_transport_serial_close();
+    }
+    APP_ERROR_CHECK(err_code);
+
+    m_update_status = BOOTLOADER_TIMEOUT;
+  }
+  else if (update_status.status_code == DFU_BANK_0_ERASED)
+  {
+    settings.bank_0_crc  = 0;
+    settings.bank_0_size = 0;
+    settings.bank_0      = BANK_INVALID_APP;
+    settings.bank_1      = p_bootloader_settings->bank_1;
+
+    bootloader_settings_save(&settings);
+  }
+  else if (update_status.status_code == DFU_RESET)
+  {
+    m_update_status = BOOTLOADER_RESET;
+  }
+  else
+  {
+    // No implementation needed.
+  }
 }
 
 
 uint32_t bootloader_init(void)
 {
-    uint32_t                err_code;
-    pstorage_module_param_t storage_params = {.cb = pstorage_callback_handler};
+  uint32_t                err_code;
+  pstorage_module_param_t storage_params = {.cb = pstorage_callback_handler};
 
-    err_code = pstorage_init();
-    VERIFY_SUCCESS(err_code);
+  err_code = pstorage_init();
+  VERIFY_SUCCESS(err_code);
 
-    m_bootsettings_handle.block_id = BOOTLOADER_SETTINGS_ADDRESS;
-    err_code = pstorage_register(&storage_params, &m_bootsettings_handle);
+  m_bootsettings_handle.block_id = BOOTLOADER_SETTINGS_ADDRESS;
+  err_code = pstorage_register(&storage_params, &m_bootsettings_handle);
 
-    return err_code;
+  return err_code;
 }
 
 
 uint32_t bootloader_dfu_start(bool ota, uint32_t timeout_ms, bool cancel_timeout_on_usb)
 {
-    uint32_t err_code;
+  uint32_t err_code;
 
-    m_cancel_timeout_on_usb = cancel_timeout_on_usb && !ota;
+  m_cancel_timeout_on_usb = cancel_timeout_on_usb && !ota;
 
-    // Clear swap if banked update is used.
-    err_code = dfu_init();
-    VERIFY_SUCCESS(err_code);
+  // Clear swap if banked update is used.
+  err_code = dfu_init();
+  VERIFY_SUCCESS(err_code);
 
-    if ( ota )
+  if ( ota )
+  {
+    err_code = dfu_transport_ble_update_start();
+  }else
+  {
+    // DFU mode with timeout can be
+    // - Forced startup DFU for nRF52832 or
+    // - Makecode single tap reset but no enumerated (battery power)
+    if ( timeout_ms )
     {
-      err_code = dfu_transport_ble_update_start();
-    }else
-    {
-      // DFU mode with timeout can be
-      // - Forced startup DFU for nRF52832 or
-      // - Makecode single tap reset but no enumerated (battery power)
-      if ( timeout_ms )
-      {
-        dfu_startup_packet_received = false;
+      dfu_startup_packet_received = false;
 
-        app_timer_create(&_dfu_startup_timer, APP_TIMER_MODE_SINGLE_SHOT, dfu_startup_timer_handler);
-        app_timer_start(_dfu_startup_timer, APP_TIMER_TICKS(timeout_ms), NULL);
-      }
-
-      err_code = dfu_transport_serial_update_start();
+      app_timer_create(&_dfu_startup_timer, APP_TIMER_MODE_SINGLE_SHOT, dfu_startup_timer_handler);
+      app_timer_start(_dfu_startup_timer, APP_TIMER_TICKS(timeout_ms), NULL);
     }
 
-    wait_for_events();
+    err_code = dfu_transport_serial_update_start();
+  }
 
-    return err_code;
+  wait_for_events();
+
+  return err_code;
 }
 
 void bootloader_app_start(void)
@@ -408,55 +406,55 @@ bool bootloader_dfu_sd_in_progress(void)
 {
   bootloader_settings_t const * p_bootloader_settings;
 
-    bootloader_util_settings_get(&p_bootloader_settings);
+  bootloader_util_settings_get(&p_bootloader_settings);
 
-    if (p_bootloader_settings->bank_0 == BANK_VALID_SD ||
-        p_bootloader_settings->bank_1 == BANK_VALID_BOOT)
-    {
-        return true;
-    }
+  if (p_bootloader_settings->bank_0 == BANK_VALID_SD ||
+      p_bootloader_settings->bank_1 == BANK_VALID_BOOT)
+  {
+    return true;
+  }
 
-    return false;
+  return false;
 }
 
 
 uint32_t bootloader_dfu_sd_update_continue(void)
 {
-    uint32_t err_code;
+  uint32_t err_code;
 
-    if ((dfu_sd_image_validate() == NRF_SUCCESS) &&
-        (dfu_bl_image_validate() == NRF_SUCCESS))
-    {
-        return NRF_SUCCESS;
-    }
+  if ((dfu_sd_image_validate() == NRF_SUCCESS) &&
+      (dfu_bl_image_validate() == NRF_SUCCESS))
+  {
+      return NRF_SUCCESS;
+  }
 
-    // Ensure that flash operations are not executed within the first 100 ms seconds to allow
-    // a debugger to be attached.
-    NRFX_DELAY_MS(100);
+  // Ensure that flash operations are not executed within the first 100 ms seconds to allow
+  // a debugger to be attached.
+  NRFX_DELAY_MS(100);
 
-    err_code = dfu_sd_image_swap();
-    APP_ERROR_CHECK(err_code);
+  err_code = dfu_sd_image_swap();
+  APP_ERROR_CHECK(err_code);
 
-    err_code = dfu_sd_image_validate();
-    APP_ERROR_CHECK(err_code);
+  err_code = dfu_sd_image_validate();
+  APP_ERROR_CHECK(err_code);
 
-    err_code = dfu_bl_image_swap();
-    APP_ERROR_CHECK(err_code);
+  err_code = dfu_bl_image_swap();
+  APP_ERROR_CHECK(err_code);
 
-    return err_code;
+  return err_code;
 }
 
 
 uint32_t bootloader_dfu_sd_update_finalize(void)
 {
-    dfu_update_status_t update_status = { 0 };
-    update_status.status_code = DFU_UPDATE_SD_SWAPPED;
+  dfu_update_status_t update_status = { 0 };
+  update_status.status_code = DFU_UPDATE_SD_SWAPPED;
 
-    bootloader_dfu_update_process(update_status);
+  bootloader_dfu_update_process(update_status);
 
-    wait_for_events();
+  wait_for_events();
 
-    return NRF_SUCCESS;
+  return NRF_SUCCESS;
 }
 
 
@@ -464,14 +462,14 @@ void bootloader_settings_get(bootloader_settings_t * const p_settings)
 {
   bootloader_settings_t const * p_bootloader_settings;
 
-    bootloader_util_settings_get(&p_bootloader_settings);
+  bootloader_util_settings_get(&p_bootloader_settings);
 
-    p_settings->bank_0         = p_bootloader_settings->bank_0;
-    p_settings->bank_0_crc     = p_bootloader_settings->bank_0_crc;
-    p_settings->bank_0_size    = p_bootloader_settings->bank_0_size;
-    p_settings->bank_1         = p_bootloader_settings->bank_1;
-    p_settings->sd_image_size  = p_bootloader_settings->sd_image_size;
-    p_settings->bl_image_size  = p_bootloader_settings->bl_image_size;
-    p_settings->app_image_size = p_bootloader_settings->app_image_size;
-    p_settings->sd_image_start = p_bootloader_settings->sd_image_start;
+  p_settings->bank_0         = p_bootloader_settings->bank_0;
+  p_settings->bank_0_crc     = p_bootloader_settings->bank_0_crc;
+  p_settings->bank_0_size    = p_bootloader_settings->bank_0_size;
+  p_settings->bank_1         = p_bootloader_settings->bank_1;
+  p_settings->sd_image_size  = p_bootloader_settings->sd_image_size;
+  p_settings->bl_image_size  = p_bootloader_settings->bl_image_size;
+  p_settings->app_image_size = p_bootloader_settings->app_image_size;
+  p_settings->sd_image_start = p_bootloader_settings->sd_image_start;
 }

--- a/lib/sdk11/components/libraries/bootloader_dfu/dfu_single_bank.c
+++ b/lib/sdk11/components/libraries/bootloader_dfu/dfu_single_bank.c
@@ -101,8 +101,8 @@ static void dfu_prepare_func_app_erase(uint32_t image_size)
   }
   else
   {
-    uint32_t page_count = m_image_size / CODE_PAGE_SIZE;
-    if ( m_image_size % CODE_PAGE_SIZE ) page_count++;
+    // ceil div
+    uint32_t const page_count = NRFX_CEIL_DIV(m_image_size, CODE_PAGE_SIZE);
 
     for ( uint32_t i = 0; i < page_count; i++ )
     {

--- a/lib/sdk11/components/libraries/bootloader_dfu/dfu_types.h
+++ b/lib/sdk11/components/libraries/bootloader_dfu/dfu_types.h
@@ -66,18 +66,12 @@ static inline bool is_sd_existed(void)
 #define DFU_REGION_TOTAL_SIZE           (BOOTLOADER_REGION_START - CODE_REGION_1_START)                 /**< Total size of the region between SD and Bootloader. */
 
 #ifndef DFU_APP_DATA_RESERVED
-#define DFU_APP_DATA_RESERVED           CODE_PAGE_SIZE*7                                                /**< Size of Application Data that must be preserved between application updates. This value must be a multiple of page size. Page size is 0x400 (1024d) bytes, thus this value must be 0x0000, 0x0400, 0x0800, 0x0C00, 0x1000, etc. */
+  #define DFU_APP_DATA_RESERVED         CODE_PAGE_SIZE*7                                                /**< Size of Application Data that must be preserved between application updates. This value must be a multiple of page size. Page size is 0x400 (1024d) bytes, thus this value must be 0x0000, 0x0400, 0x0800, 0x0C00, 0x1000, etc. */
 #endif
 
 #define DFU_IMAGE_MAX_SIZE_FULL         (DFU_REGION_TOTAL_SIZE - DFU_APP_DATA_RESERVED)                 /**< Maximum size of an application, excluding save data from the application. */
-                                          
-#define DFU_IMAGE_MAX_SIZE_BANKED       (((DFU_IMAGE_MAX_SIZE_FULL) - \
-                                        (DFU_IMAGE_MAX_SIZE_FULL % (2 * CODE_PAGE_SIZE)))/2)            /**< Maximum size of an application, excluding save data from the application. */
-
-#define DFU_BL_IMAGE_MAX_SIZE           (BOOTLOADER_MBR_PARAMS_PAGE_ADDRESS - BOOTLOADER_REGION_START)         /**< Maximum size of a bootloader, excluding save data from the current bootloader. */
-
+#define DFU_BL_IMAGE_MAX_SIZE           (BOOTLOADER_MBR_PARAMS_PAGE_ADDRESS - BOOTLOADER_REGION_START)  /**< Maximum size of a bootloader, excluding save data from the current bootloader. */
 #define DFU_BANK_0_REGION_START         CODE_REGION_1_START                                             /**< Bank 0 region start. */
-#define DFU_BANK_1_REGION_START         (DFU_BANK_0_REGION_START + DFU_IMAGE_MAX_SIZE_BANKED)           /**< Bank 1 region start. */
 
 #define EMPTY_FLASH_MASK                0xFFFFFFFF                                                      /**< Bit mask that defines an empty address in flash. */
 

--- a/lib/sdk11/components/libraries/bootloader_dfu/dfu_types.h
+++ b/lib/sdk11/components/libraries/bootloader_dfu/dfu_types.h
@@ -47,14 +47,14 @@ static inline bool is_sd_existed(void)
 #define SOFTDEVICE_REGION_START             MBR_SIZE                    /**< This field should correspond to start address of the bootloader, found in UICR.RESERVED, 0x10001014, register. This value is used for sanity check, so the bootloader will fail immediately if this value differs from runtime value. The value is used to determine max application size for updating. */
 #define CODE_PAGE_SIZE                      0x1000                      /**< Size of a flash codepage. Used for size of the reserved flash space in the bootloader region. Will be runtime checked against NRF_UICR->CODEPAGESIZE to ensure the region is correct. */
 
-// Flash = 512 KB
 #if defined(NRF52832_XXAA) || defined(NRF52833_XXAA)
+  // Flash = 512 KB
   #define BOOTLOADER_REGION_START             0x00074000                  /**< This field should correspond to start address of the bootloader, found in UICR.RESERVED, 0x10001014, register. This value is used for sanity check, so the bootloader will fail immediately if this value differs from runtime value. The value is used to determine max application size for updating. */
   #define BOOTLOADER_MBR_PARAMS_PAGE_ADDRESS  0x0007E000                  /**< The field specifies the page location of the mbr params page address. */
   #define BOOTLOADER_SETTINGS_ADDRESS         0x0007F000                  /**< The field specifies the page location of the bootloader settings address. */
 
-// Flash = 1024 KB
 #elif  defined(NRF52840_XXAA)
+  // Flash = 1024 KB
   #define BOOTLOADER_REGION_START             0x000F4000                  /**< This field should correspond to start address of the bootloader, found in UICR.RESERVED, 0x10001014, register. This value is used for sanity check, so the bootloader will fail immediately if this value differs from runtime value. The value is used to determine max application size for updating. */
   #define BOOTLOADER_MBR_PARAMS_PAGE_ADDRESS  0x000FE000                  /**< The field specifies the page location of the mbr params page address. */
   #define BOOTLOADER_SETTINGS_ADDRESS         0x000FF000                  /**< The field specifies the page location of the bootloader settings address. */
@@ -66,7 +66,7 @@ static inline bool is_sd_existed(void)
 #define DFU_REGION_TOTAL_SIZE           (BOOTLOADER_REGION_START - CODE_REGION_1_START)                 /**< Total size of the region between SD and Bootloader. */
 
 #ifndef DFU_APP_DATA_RESERVED
-  #define DFU_APP_DATA_RESERVED         CODE_PAGE_SIZE*7                                                /**< Size of Application Data that must be preserved between application updates. This value must be a multiple of page size. Page size is 0x400 (1024d) bytes, thus this value must be 0x0000, 0x0400, 0x0800, 0x0C00, 0x1000, etc. */
+  #error "DFU_APP_DATA_RESERVED is not defined"
 #endif
 
 #define DFU_IMAGE_MAX_SIZE_FULL         (DFU_REGION_TOTAL_SIZE - DFU_APP_DATA_RESERVED)                 /**< Maximum size of an application, excluding save data from the application. */

--- a/linker/nrf52840.ld
+++ b/linker/nrf52840.ld
@@ -11,9 +11,9 @@ MEMORY
    *  those values do not match. The check is performed in main.c, see
    *  APP_ERROR_CHECK_BOOL(*((uint32_t *)NRF_UICR_BOOT_START_ADDRESS) == BOOTLOADER_REGION_START);
    */
-  FLASH (rx) : ORIGIN = 0xF4000, LENGTH = 0xFE000-0xF4000-2048 /* 38 KB */
+  FLASH (rx) : ORIGIN = 0xF4000, LENGTH = 0xFE000-0xF4000 - 2K /* 38 KB */
 
-  BOOTLOADER_CONFIG (r): ORIGIN = 0xFE000 - 2048, LENGTH = 2048
+  BOOTLOADER_CONFIG (r): ORIGIN = 0xFE000 - 2K, LENGTH = 2K
 
   /** Location of mbr params page in flash. */
   MBR_PARAMS_PAGE (rw) : ORIGIN = 0xFE000, LENGTH = 0x1000

--- a/src/main.c
+++ b/src/main.c
@@ -157,8 +157,6 @@ void softdev_mbr_init(void)
 //--------------------------------------------------------------------+
 int main(void)
 {
-  PRINTF("Bootlaoder Start\r\n");
-
   // Populate Boot Address and MBR Param into MBR if not already
   // MBR_BOOTLOADER_ADDR/MBR_PARAM_PAGE_ADDR are used if available, else UICR registers are used
   // Note: skip it for now since this will prevent us to change the size of bootloader in the future
@@ -189,6 +187,8 @@ int main(void)
 
   board_init();
   bootloader_init();
+
+  PRINTF("Bootloader Start\r\n");
 
   led_state(STATE_BOOTLOADER_STARTED);
 
@@ -320,7 +320,7 @@ int main(void)
  * "Master Boot Record and SoftDevice initializaton procedure"
  *
  * @param[in] init_softdevice  true if SoftDevice should be initialized. The SoftDevice must only
- *                             be initialized if a chip reset has occured. Soft reset (jump ) from
+ *                             be initialized if a chip reset has occurred. Soft reset (jump ) from
  *                             application must not reinitialize the SoftDevice.
  */
 static uint32_t softdev_init(bool init_softdevice)
@@ -359,7 +359,7 @@ static uint32_t softdev_init(bool init_softdevice)
   // NRF_DFU_BLE_REQUIRES_BONDS
   varclr(&blecfg);
   blecfg.gatts_cfg.service_changed.service_changed = 1;
-   sd_ble_cfg_set(BLE_GATTS_CFG_SERVICE_CHANGED, &blecfg, ram_start) ;
+  sd_ble_cfg_set(BLE_GATTS_CFG_SERVICE_CHANGED, &blecfg, ram_start);
 
   // ATT MTU
   varclr(&blecfg);
@@ -471,7 +471,7 @@ uint32_t proc_soc(void)
   return err;
 }
 
-void ada_sd_task(void* evt_data, uint16_t evt_size)
+void proc_sd_task(void* evt_data, uint16_t evt_size)
 {
   (void) evt_data;
   (void) evt_size;
@@ -486,7 +486,7 @@ void ada_sd_task(void* evt_data, uint16_t evt_size)
 void SD_EVT_IRQHandler(void)
 {
   // Use App Scheduler to defer handling code in non-isr context
-  app_sched_event_put(NULL, 0, ada_sd_task);
+  app_sched_event_put(NULL, 0, proc_sd_task);
 }
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -197,8 +197,8 @@ int main(void)
   {
     led_state(STATE_WRITING_STARTED);
 
-    APP_ERROR_CHECK( bootloader_dfu_sd_update_continue() );
-    APP_ERROR_CHECK( bootloader_dfu_sd_update_finalize() );
+    bootloader_dfu_sd_update_continue();
+    bootloader_dfu_sd_update_finalize();
 
     led_state(STATE_WRITING_FINISHED);
   }
@@ -264,12 +264,12 @@ int main(void)
       if (APP_ASKS_FOR_SINGLE_TAP_RESET() || uf2_dfu || serial_only_dfu)
       {
         // If USB is not enumerated in 3s (eg. because we're running on battery), we restart into app.
-        APP_ERROR_CHECK( bootloader_dfu_start(_ota_dfu, 3000, true) );
+         bootloader_dfu_start(_ota_dfu, 3000, true);
       }
       else
       {
         // No timeout if bootloader requires user action (double-reset).
-        APP_ERROR_CHECK( bootloader_dfu_start(_ota_dfu, 0, false) );
+         bootloader_dfu_start(_ota_dfu, 0, false);
       }
 
       if ( _ota_dfu )
@@ -328,7 +328,7 @@ static uint32_t softdev_init(bool init_softdevice)
   if (init_softdevice) softdev_mbr_init();
 
   // Forward vector table to bootloader address so that we can handle BLE events
-  APP_ERROR_CHECK( sd_softdevice_vector_table_base_set(BOOTLOADER_REGION_START) );
+  sd_softdevice_vector_table_base_set(BOOTLOADER_REGION_START);
 
   // Enable Softdevice, Use Internal OSC to compatible with all boards
   nrf_clock_lf_cfg_t clock_cfg =
@@ -339,7 +339,7 @@ static uint32_t softdev_init(bool init_softdevice)
       .accuracy     = NRF_CLOCK_LF_ACCURACY_250_PPM
   };
 
-  APP_ERROR_CHECK( sd_softdevice_enable(&clock_cfg, app_error_fault_handler) );
+  sd_softdevice_enable(&clock_cfg, app_error_fault_handler);
   sd_nvic_EnableIRQ(SD_EVT_IRQn);
 
   /*------------- Configure BLE params  -------------*/
@@ -354,35 +354,35 @@ static uint32_t softdev_init(bool init_softdevice)
   blecfg.gap_cfg.role_count_cfg.periph_role_count  = 1;
   blecfg.gap_cfg.role_count_cfg.central_role_count = 0;
   blecfg.gap_cfg.role_count_cfg.central_sec_count  = 0;
-  APP_ERROR_CHECK( sd_ble_cfg_set(BLE_GAP_CFG_ROLE_COUNT, &blecfg, ram_start) );
+  sd_ble_cfg_set(BLE_GAP_CFG_ROLE_COUNT, &blecfg, ram_start);
 
   // NRF_DFU_BLE_REQUIRES_BONDS
   varclr(&blecfg);
   blecfg.gatts_cfg.service_changed.service_changed = 1;
-  APP_ERROR_CHECK( sd_ble_cfg_set(BLE_GATTS_CFG_SERVICE_CHANGED, &blecfg, ram_start) );
+   sd_ble_cfg_set(BLE_GATTS_CFG_SERVICE_CHANGED, &blecfg, ram_start) ;
 
   // ATT MTU
   varclr(&blecfg);
   blecfg.conn_cfg.conn_cfg_tag = BLE_CONN_CFG_HIGH_BANDWIDTH;
   blecfg.conn_cfg.params.gatt_conn_cfg.att_mtu = BLEGATT_ATT_MTU_MAX;
-  APP_ERROR_CHECK( sd_ble_cfg_set(BLE_CONN_CFG_GATT, &blecfg, ram_start) );
+  sd_ble_cfg_set(BLE_CONN_CFG_GATT, &blecfg, ram_start);
 
   // Event Length + HVN queue + WRITE CMD queue setting affecting bandwidth
   varclr(&blecfg);
   blecfg.conn_cfg.conn_cfg_tag = BLE_CONN_CFG_HIGH_BANDWIDTH;
   blecfg.conn_cfg.params.gap_conn_cfg.conn_count   = 1;
   blecfg.conn_cfg.params.gap_conn_cfg.event_length = BLEGAP_EVENT_LENGTH;
-  APP_ERROR_CHECK( sd_ble_cfg_set(BLE_CONN_CFG_GAP, &blecfg, ram_start) );
+  sd_ble_cfg_set(BLE_CONN_CFG_GAP, &blecfg, ram_start);
 
   // Enable BLE stack.
   // Note: Interrupt state (enabled, forwarding) is not work properly if not enable ble
-  APP_ERROR_CHECK( sd_ble_enable(&ram_start) );
+  sd_ble_enable(&ram_start);
 
 #if 0
   ble_opt_t  opt;
   varclr(&opt);
   opt.common_opt.conn_evt_ext.enable = 1; // enable Data Length Extension
-  APP_ERROR_CHECK( sd_ble_opt_set(BLE_COMMON_OPT_CONN_EVT_EXT, &opt) );
+  sd_ble_opt_set(BLE_COMMON_OPT_CONN_EVT_EXT, &opt);
 #endif
 
   return NRF_SUCCESS;

--- a/src/usb/uf2/ghostfat.c
+++ b/src/usb/uf2/ghostfat.c
@@ -587,6 +587,5 @@ int write_block (uint32_t block_no, uint8_t *data, WriteState *state)
     }
   }
 
-  STATIC_ASSERT(BPB_SECTOR_SIZE == 512); // if sector size changes, may need to re-validate this code
   return BPB_SECTOR_SIZE;
 }

--- a/src/usb/uf2/uf2cfg.h
+++ b/src/usb/uf2/uf2cfg.h
@@ -18,7 +18,7 @@
 
 // Application Address Space
 #define USER_FLASH_START          MBR_SIZE // skip MBR included in SD hex
-#define USER_FLASH_END            0xAD000
+#define USER_FLASH_END            (BOOTLOADER_REGION_START - DFU_APP_DATA_RESERVED)
 
 // Bootloader start address
 #define BOOTLOADER_ADDR_START         BOOTLOADER_REGION_START


### PR DESCRIPTION
fix #213 

```
Write addr = 0x000ACD00, block = 2142 (2142 of 2191)
Write addr = 0x000ACE00, block = 2143 (2143 of 2191)
Write addr = 0x000ACF00, block = 2144 (2144 of 2191)
```

I found the issue, the bootloader is limited its size to 512KB since it reserved the rest for internal file system ( for all boards), since the very first implementation of the bootloader.
- For Arduino, all boards is served with 28KB for storing bonding information. 
- For Circuitpython, there seems to be 3 section FLASH_BLE_CONFIG (32KB), FLASH_NVM (8KB), FLASH_FATFS (can be 0 on qspi flash dev).

For that I think we will increase reserved size to 40KB. The overflow to fatfs should be checked by circuitpyhon  linker, just try DEBUG=1 with boards internal flash, it overflows and won't linked which is good.

![](https://cdn-learn.adafruit.com/assets/assets/000/065/418/medium640/microcontrollers_S132_and_S140_v6.png?1541757141)

_Originally posted by @hathach in https://github.com/adafruit/Adafruit_nRF52_Bootloader/issues/213#issuecomment-892501613_