### PR TITLE
Add New Board: BlueMicro833

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -32,6 +32,7 @@ jobs:
           - 'arcade_feather_nrf52840_express'
           - 'arduino_nano_33_ble'
           - 'bast_ble'
+          - 'bluemicro_nrf52833'
           - 'bluemicro_nrf52840'
           - 'ebyte_e104_bt5032a'
           - 'ebyte_e73_tbb'

--- a/src/boards/bluemicro_nrf52833/board.h
+++ b/src/boards/bluemicro_nrf52833/board.h
@@ -1,0 +1,69 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Pierre Constantineau
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef _BLUEMICRO_NRF52833_H
+#define _BLUEMICRO_NRF52833_H
+
+#define _PINNUM(port, pin)    ((port)*32 + (pin))
+
+/*------------------------------------------------------------------*/
+/* LED
+ *------------------------------------------------------------------*/
+#define LEDS_NUMBER           2
+#define LED_PRIMARY_PIN       _PINNUM(1, 4)
+#define LED_SECONDARY_PIN     _PINNUM(0, 25)
+#define LED_STATE_ON          1
+
+#define LED_NEOPIXEL          _PINNUM(0, 7)
+#define NEOPIXELS_NUMBER      1
+#define BOARD_RGB_BRIGHTNESS  0x040404
+
+/*------------------------------------------------------------------*/
+/* BUTTON
+ *------------------------------------------------------------------*/
+#define BUTTONS_NUMBER    2                 // none connected at all
+#define BUTTON_1          _PINNUM(0, 18)    // unusable: RESET
+#define BUTTON_2          _PINNUM(1, 1)     // no connection on E73-2G4M08S1E Module
+#define BUTTON_PULL       NRF_GPIO_PIN_PULLUP
+
+//--------------------------------------------------------------------+
+// BLE OTA
+//--------------------------------------------------------------------+
+#define BLEDIS_MANUFACTURER  "BlueMicro"
+#define BLEDIS_MODEL         "BlueMicro 833"
+
+//--------------------------------------------------------------------+
+// USB PID from openmoko:
+// PR https://github.com/openmoko/openmoko-usb-oui/pull/34
+//--------------------------------------------------------------------+
+#define USB_DESC_VID           0x1d50
+#define USB_DESC_UF2_PID       0x616f
+#define USB_DESC_CDC_ONLY_PID  0x616f
+
+#define UF2_PRODUCT_NAME  "BlueMicro"
+#define UF2_VOLUME_LABEL  "BLUEMICRO"
+#define UF2_BOARD_ID      "nRF52833-BlueMicro-v1"
+#define UF2_INDEX_URL     "http://bluemicro.jpconstantineau.com/"
+
+#endif // _BLUEMICRO_H

--- a/src/boards/bluemicro_nrf52833/board.mk
+++ b/src/boards/bluemicro_nrf52833/board.mk
@@ -1,0 +1,1 @@
+MCU_SUB_VARIANT = nrf52833

--- a/src/boards/bluemicro_nrf52833/pinconfig.c
+++ b/src/boards/bluemicro_nrf52833/pinconfig.c
@@ -1,0 +1,19 @@
+#include "boards.h"
+#include "uf2/configkeys.h"
+
+__attribute__((used, section(".bootloaderConfig")))
+const uint32_t bootloaderConfig[] =
+{
+  /* CF2 START */
+  CFG_MAGIC0, CFG_MAGIC1,                       // magic
+  5, 100,                                       // used entries, total entries
+
+  204, 0x100000,                                // FLASH_BYTES = 0x100000
+  205, 0x40000,                                 // RAM_BYTES = 0x40000
+  208, (USB_DESC_VID << 16) | USB_DESC_UF2_PID, // BOOTLOADER_BOARD_ID = USB VID+PID, used for verification when updating bootloader via uf2
+  209, 0xada52840,                              // UF2_FAMILY = 0xada52840
+  210, 0x20,                                    // PINS_PORT_SIZE = PA_32
+
+  0, 0, 0, 0, 0, 0, 0, 0
+  /* CF2 END */
+};


### PR DESCRIPTION
Adding a nRF52833 board with the form factor of a Pro Micro that uses the EByte E73-2G4M08S1E Module.

Waiting on approval of PID request at openmoko:
https://github.com/openmoko/openmoko-usb-oui/pull/34

If anyone is interested:
Hardware design files: https://github.com/jpconstantineau/BlueMicro833_hardware