### PR TITLE
Add linkermap target for size analysis

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -83,6 +83,7 @@ jobs:
     
     - name: Build
       run: |
+        git describe --dirty --always --tags
         make BOARD=${{ matrix.board }} print-_VER print-GIT_VERSION print-CFLAGS
         make BOARD=${{ matrix.board }} all
         make BOARD=${{ matrix.board }} copy-artifact

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -61,20 +61,20 @@ jobs:
       uses: actions/setup-node@v1
       
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v1
       with:
         submodules: true
 
-    #- name: Checkout linkermap
-    #  uses: actions/checkout@v2
-    #  with:
-    #     repository: hathach/linkermap
-    #     path: linkermap
+    - name: Checkout linkermap
+      uses: actions/checkout@v2
+      with:
+         repository: hathach/linkermap
+         path: linkermap
         
     - name: Install Toolchains
       run: |
         pip3 install adafruit-nrfutil uritemplate requests intelhex
-        #pip3 install linkermap/
+        pip3 install linkermap/
         npm install --global xpm
         # 9.3.1-1.2.1 is xpack modified version which significantly increased compiled size to 6-7KB and cause flash overflow.
         # Skip this version for now, we will try again with next official release from ARM

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -65,16 +65,16 @@ jobs:
       with:
         submodules: true
 
-    - name: Checkout linkermap
-      uses: actions/checkout@v2
-      with:
-         repository: hathach/linkermap
-         path: linkermap
+    #- name: Checkout linkermap
+    #  uses: actions/checkout@v2
+    #  with:
+    #     repository: hathach/linkermap
+    #     path: linkermap
         
     - name: Install Toolchains
       run: |
         pip3 install adafruit-nrfutil uritemplate requests intelhex
-        pip3 install linkermap/
+        #pip3 install linkermap/
         npm install --global xpm
         # 9.3.1-1.2.1 is xpack modified version which significantly increased compiled size to 6-7KB and cause flash overflow.
         # Skip this version for now, we will try again with next official release from ARM

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -83,6 +83,7 @@ jobs:
     
     - name: Build
       run: |
+        make BOARD=${{ matrix.board }} print-_VER print-GIT_VERSION print-CFLAGS
         make BOARD=${{ matrix.board }} all
         make BOARD=${{ matrix.board }} copy-artifact
 

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -83,8 +83,6 @@ jobs:
     
     - name: Build
       run: |
-        git describe --dirty --always --tags
-        make BOARD=${{ matrix.board }} print-_VER print-GIT_VERSION print-CFLAGS
         make BOARD=${{ matrix.board }} all
         make BOARD=${{ matrix.board }} copy-artifact
 

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -61,13 +61,20 @@ jobs:
       uses: actions/setup-node@v1
       
     - name: Checkout Code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
-        submodules: true      
+        submodules: true
+
+    - name: Checkout linkermap
+      uses: actions/checkout@v2
+      with:
+         repository: hathach/linkermap
+         path: linkermap
         
     - name: Install Toolchains
       run: |
         pip3 install adafruit-nrfutil uritemplate requests intelhex
+        pip3 install linkermap/
         npm install --global xpm
         # 9.3.1-1.2.1 is xpack modified version which significantly increased compiled size to 6-7KB and cause flash overflow.
         # Skip this version for now, we will try again with next official release from ARM
@@ -78,6 +85,9 @@ jobs:
       run: |
         make BOARD=${{ matrix.board }} all
         make BOARD=${{ matrix.board }} copy-artifact
+
+    - name: Linker Map
+      run: make BOARD=${{ matrix.board }} linkermap
       
     - uses: actions/upload-artifact@v2
       with:

--- a/Makefile
+++ b/Makefile
@@ -373,6 +373,10 @@ clean:
 	@$(RM) $(BUILD)
 	@$(RM) $(BIN)
 
+# linkermap must be install previously at https://github.com/hathach/linkermap
+linkermap: $(BUILD)/$(OUT_NAME).out
+	@linkermap -v $<.map
+
 # Create objects from C SRC files
 $(BUILD)/%.o: %.c
 	@echo CC $(notdir $<)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a CDC/DFU/UF2 bootloader for nRF52 boards.
 - [Adafruit Feather nRF52840 Express](https://www.adafruit.com/product/4062)
 - [Adafruit Feather nRF52840 Sense](https://www.adafruit.com/product/4516)
 - [Adafruit ItsyBitsy nRF52840 Express](https://www.adafruit.com/product/4481)
+- [Adafruit LED Glasses Driver nRF52840](https://www.adafruit.com/product/5217)
 - Adafruit Metro nRF52840 Express
 - [Akizukidenshi AE-BL652-BO](https://akizukidenshi.com/catalog/g/gK-15567/)
 - [Electronut Labs Papyr](https://docs.electronut.in/papyr/)

--- a/src/boards/ledglasses_nrf52840/board.h
+++ b/src/boards/ledglasses_nrf52840/board.h
@@ -63,6 +63,6 @@
 #define UF2_PRODUCT_NAME   "Adafruit LED Glasses Driver nRF52840"
 #define UF2_VOLUME_LABEL   "GLASSESBOOT"
 #define UF2_BOARD_ID       "nRF52840-LedGlasses-revA"
-#define UF2_INDEX_URL      "https://www.adafruit.com/"
+#define UF2_INDEX_URL      "https://www.adafruit.com/product/5217"
 
 #endif // _LEDGLASSES_NRF52840_H


### PR DESCRIPTION
- linkermap target is added for size analysis
- ci also include linkermap output for quick and convenient check https://github.com/adafruit/Adafruit_nRF52_Bootloader/runs/3871902600?check_suite_focus=true#step:8:10 . Example output is

```
                                              File |   .text   .data    .bss   Total
------------------------------------------------------------------------------------
                                      msc_device.o |    1772       0    4160    5932
                                      ------------ |--------------------------------
                                  .bss._mscd_buf   |       0       0    4096    4096
                                    mscd_xfer_cb   |    1208       0       0    1208
               .text.proc_read10_cmd.constprop.0   |     172       0       0     172
                                       mscd_open   |     128       0       0     128
              .text.proc_write10_cmd.constprop.0   |     112       0       0     112
                            mscd_control_xfer_cb   |      96       0       0      96
                                  .bss._mscd_itf   |       0       0      64      64
                               tud_msc_set_sense   |      24       0       0      24
                                       mscd_init   |      16       0       0      16
                                      mscd_reset   |      16       0       0      16
------------------------------------------------------------------------------------
                                    hci_mem_pool.o |     348       0    4861    5209
                                    -------------- |--------------------------------
                     .bss.m_rx_buffer_elem_queue   |       0       0    4832    4832
                         hci_mem_pool_rx_consume   |     120       0       0     120
                         hci_mem_pool_rx_produce   |      84       0       0      84
                         hci_mem_pool_rx_extract   |      68       0       0      68
                               hci_mem_pool_open   |      40       0       0      40
                   hci_mem_pool_rx_data_size_set   |      32       0       0      32
                          .bss.m_rx_buffer_queue   |       0       0      28      28
                              hci_mem_pool_close   |       4       0       0       4
                          .bss.m_is_tx_allocated   |       0       0       1       1
------------------------------------------------------------------------------------
                                     flash_nrf5x.o |     140       4    4096    4240
                                     ------------- |--------------------------------
                                    .bss._fl_buf   |       0       0    4096    4096
                               flash_nrf5x_write   |      80       0       0      80
                               flash_nrf5x_flush   |      60       0       0      60
                                  .data._fl_addr   |       0       4       0       4
------------------------------------------------------------------------------------
```

