### PR TITLE
Add ci to build binary for raytac_mdbt50q_db_40

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -50,6 +50,7 @@ jobs:
           - 'pca10059'
           - 'pca10100'
           - 'pitaya_go'
+          - 'raytac_mdbt50q_db_40'
           - 'raytac_mdbt50q_rx'
           - 'sparkfun_nrf52840_micromod'
           - 'waveshare_nrf52840_eval'


### PR DESCRIPTION
everything look good, only one last thing: you need add the board to ci list so that its binaries is generated when released https://github.com/adafruit/Adafruit_nRF52_Bootloader/blob/master/.github/workflows/githubci.yml

