### PR TITLE
nRF52833 updates to UF2/memory map for nRF52833 boards

### DIFF
--- a/src/boards/bluemicro_nrf52833/pinconfig.c
+++ b/src/boards/bluemicro_nrf52833/pinconfig.c
@@ -8,8 +8,8 @@ const uint32_t bootloaderConfig[] =
   CFG_MAGIC0, CFG_MAGIC1,                       // magic
   5, 100,                                       // used entries, total entries
 
-  204, 0x80000,                                // FLASH_BYTES = 0x100000/2=0x80000
-  205, 0x20000,                                 // RAM_BYTES = 0x40000/2=0x20000
+  204, 0x80000,                                 // FLASH_BYTES
+  205, 0x20000,                                 // RAM_BYTES
   208, (USB_DESC_VID << 16) | USB_DESC_UF2_PID, // BOOTLOADER_BOARD_ID = USB VID+PID, used for verification when updating bootloader via uf2
   209, 0xada52840,                              // UF2_FAMILY = 0xada52840
   210, 0x20,                                    // PINS_PORT_SIZE = PA_32

--- a/src/boards/bluemicro_nrf52833/pinconfig.c
+++ b/src/boards/bluemicro_nrf52833/pinconfig.c
@@ -8,8 +8,8 @@ const uint32_t bootloaderConfig[] =
   CFG_MAGIC0, CFG_MAGIC1,                       // magic
   5, 100,                                       // used entries, total entries
 
-  204, 0x100000,                                // FLASH_BYTES = 0x100000
-  205, 0x40000,                                 // RAM_BYTES = 0x40000
+  204, 0x80000,                                // FLASH_BYTES = 0x100000/2=0x80000
+  205, 0x20000,                                 // RAM_BYTES = 0x40000/2=0x20000
   208, (USB_DESC_VID << 16) | USB_DESC_UF2_PID, // BOOTLOADER_BOARD_ID = USB VID+PID, used for verification when updating bootloader via uf2
   209, 0xada52840,                              // UF2_FAMILY = 0xada52840
   210, 0x20,                                    // PINS_PORT_SIZE = PA_32

--- a/src/boards/pca10100/pinconfig.c
+++ b/src/boards/pca10100/pinconfig.c
@@ -8,8 +8,8 @@ const uint32_t bootloaderConfig[] =
   CFG_MAGIC0, CFG_MAGIC1,                       // magic
   5, 100,                                       // used entries, total entries
 
-  204, 0x80000,                                // FLASH_BYTES = 0x100000/2=0x80000
-  205, 0x20000,                                 // RAM_BYTES = 0x40000/2=0x20000
+  204, 0x80000,                                 // FLASH_BYTES
+  205, 0x20000,                                 // RAM_BYTES
   208, (USB_DESC_VID << 16) | USB_DESC_UF2_PID, // BOOTLOADER_BOARD_ID = USB VID+PID, used for verification when updating bootloader via uf2
   209, 0xada52840,                              // UF2_FAMILY = 0xada52840
   210, 0x20,                                    // PINS_PORT_SIZE = PA_32

--- a/src/boards/pca10100/pinconfig.c
+++ b/src/boards/pca10100/pinconfig.c
@@ -8,8 +8,8 @@ const uint32_t bootloaderConfig[] =
   CFG_MAGIC0, CFG_MAGIC1,                       // magic
   5, 100,                                       // used entries, total entries
 
-  204, 0x100000,                                // FLASH_BYTES = 0x100000
-  205, 0x40000,                                 // RAM_BYTES = 0x40000
+  204, 0x80000,                                // FLASH_BYTES = 0x100000/2=0x80000
+  205, 0x20000,                                 // RAM_BYTES = 0x40000/2=0x20000
   208, (USB_DESC_VID << 16) | USB_DESC_UF2_PID, // BOOTLOADER_BOARD_ID = USB VID+PID, used for verification when updating bootloader via uf2
   209, 0xada52840,                              // UF2_FAMILY = 0xada52840
   210, 0x20,                                    // PINS_PORT_SIZE = PA_32

--- a/src/usb/uf2/uf2cfg.h
+++ b/src/usb/uf2/uf2cfg.h
@@ -14,11 +14,19 @@
 #define CFG_UF2_FAMILY_BOOT_ID    0xd663823c
 
 #define CFG_UF2_NUM_BLOCKS        0x10109     // just under 32MB
-#define CFG_UF2_FLASH_SIZE        (1024*1024) // 1 MB
+#if defined(NRF52833_XXAA)
+    #define CFG_UF2_FLASH_SIZE        0x80000 // 512 kB
+#else
+    #define CFG_UF2_FLASH_SIZE        (1024*1024) // 1 MB
+#endif
 
 // Application Address Space
 #define USER_FLASH_START          MBR_SIZE // skip MBR included in SD hex
-#define USER_FLASH_END            (BOOTLOADER_REGION_START - DFU_APP_DATA_RESERVED)
+#if defined(NRF52833_XXAA)
+    #define USER_FLASH_END            0x2D000
+#else
+    #define USER_FLASH_END            0xAD000
+#endif
 
 // Bootloader start address
 #define BOOTLOADER_ADDR_START         BOOTLOADER_REGION_START

--- a/src/usb/uf2/uf2cfg.h
+++ b/src/usb/uf2/uf2cfg.h
@@ -22,11 +22,7 @@
 
 // Application Address Space
 #define USER_FLASH_START          MBR_SIZE // skip MBR included in SD hex
-#if defined(NRF52833_XXAA)
-    #define USER_FLASH_END            0x2D000
-#else
-    #define USER_FLASH_END            0xAD000
-#endif
+#define USER_FLASH_END            (BOOTLOADER_REGION_START - DFU_APP_DATA_RESERVED)
 
 // Bootloader start address
 #define BOOTLOADER_ADDR_START         BOOTLOADER_REGION_START


### PR DESCRIPTION
Making these changes from the comments [here](https://github.com/adafruit/Adafruit_nRF52_Bootloader/pull/226#issuecomment-980806341)

Memory size was indicated incorrectly for the bootloaderconfig section.

Also bringing the minor update that @braingram added to the UF2 include file in PR #198 .
As such, this should also close PR #198 