### PR TITLE
Use separate UF2_FAMILY for nRF52833

### DIFF
--- a/src/boards/bluemicro_nrf52833/pinconfig.c
+++ b/src/boards/bluemicro_nrf52833/pinconfig.c
@@ -11,7 +11,7 @@ const uint32_t bootloaderConfig[] =
   204, 0x80000,                                 // FLASH_BYTES
   205, 0x20000,                                 // RAM_BYTES
   208, (USB_DESC_VID << 16) | USB_DESC_UF2_PID, // BOOTLOADER_BOARD_ID = USB VID+PID, used for verification when updating bootloader via uf2
-  209, 0xada52840,                              // UF2_FAMILY = 0xada52840
+  209, 0x621e937a,                              // UF2_FAMILY = 0x621e937a
   210, 0x20,                                    // PINS_PORT_SIZE = PA_32
 
   0, 0, 0, 0, 0, 0, 0, 0

--- a/src/boards/pca10100/pinconfig.c
+++ b/src/boards/pca10100/pinconfig.c
@@ -11,7 +11,7 @@ const uint32_t bootloaderConfig[] =
   204, 0x80000,                                 // FLASH_BYTES
   205, 0x20000,                                 // RAM_BYTES
   208, (USB_DESC_VID << 16) | USB_DESC_UF2_PID, // BOOTLOADER_BOARD_ID = USB VID+PID, used for verification when updating bootloader via uf2
-  209, 0xada52840,                              // UF2_FAMILY = 0xada52840
+  209, 0x621e937a,                              // UF2_FAMILY = 0x621e937a
   210, 0x20,                                    // PINS_PORT_SIZE = PA_32
 
   0, 0, 0, 0, 0, 0, 0, 0

--- a/src/usb/uf2/uf2cfg.h
+++ b/src/usb/uf2/uf2cfg.h
@@ -2,7 +2,11 @@
 #include "dfu_types.h"
 
 // Family ID for updating generic Application
-#define CFG_UF2_FAMILY_APP_ID     0xADA52840
+#if defined(NRF52833_XXAA)
+    #define CFG_UF2_FAMILY_APP_ID     0x621E937A
+#else
+    #define CFG_UF2_FAMILY_APP_ID     0xADA52840
+#endif
 
 // Board-specific ID for board-specific Application
 #if defined(USB_DESC_VID) && defined(USB_DESC_UF2_PID) && USB_DESC_VID && USB_DESC_UF2_PID


### PR DESCRIPTION
Per my understanding, the logic in `src/usb/uf2/ghostfat.c` will prevent nRF52840 UF2 firmware from being flashed to nRF52833 and vice versa (so long as `uf2conv.py` is invoked with the correct UF2_FAMILY token).