### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -74,7 +74,6 @@ jobs:
          path: linkermap
 
     - name: Set Toolchain URL
-      # 9.3.1-1.2.1 is xpack modified version which significantly increased compiled size to 6-7KB and cause flash overflow.
       run: echo >> $GITHUB_ENV TOOLCHAIN_URL=https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v10.2.1-1.1/xpack-arm-none-eabi-gcc-10.2.1-1.1-linux-x64.tar.gz
 
     - name: Cache Toolchain

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -59,31 +59,47 @@ jobs:
 
     steps:
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
 
     - name: Setup Node.js
       uses: actions/setup-node@v1
       
     - name: Checkout Code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
       with:
         submodules: true
 
     - name: Checkout linkermap
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
          repository: hathach/linkermap
          path: linkermap
-        
-    - name: Install Toolchains
+
+    - name: Set Toolchain URL
+      # 9.3.1-1.2.1 is xpack modified version which significantly increased compiled size to 6-7KB and cause flash overflow.
+      run: echo >> $GITHUB_ENV TOOLCHAIN_URL=https://github.com/xpack-dev-tools/arm-none-eabi-gcc-xpack/releases/download/v10.2.1-1.1/xpack-arm-none-eabi-gcc-10.2.1-1.1-linux-x64.tar.gz
+
+    - name: Cache Toolchain
+      uses: actions/cache@v3
+      id: cache-toolchain
+      with:
+        path: ~/cache/
+        key: ${{ runner.os }}-22-05-17-${{ env.TOOLCHAIN_URL }}
+
+    - name: Install Toolchain
+      if: steps.cache-toolchain.outputs.cache-hit != 'true'
+      run: |
+        mkdir -p ~/cache/toolchain
+        wget --progress=dot:mega $TOOLCHAIN_URL -O toolchain.tar.gz
+        tar -C ~/cache/toolchain -xaf toolchain.tar.gz
+
+    - name: Set Toolchain Path
+      run: echo >> $GITHUB_PATH `echo ~/cache/toolchain/*/bin`
+
+    - name: Install Tools
       run: |
         pip3 install adafruit-nrfutil uritemplate requests intelhex
         pip3 install linkermap/
-        npm install --global xpm
-        # 9.3.1-1.2.1 is xpack modified version which significantly increased compiled size to 6-7KB and cause flash overflow.
-        # Skip this version for now, we will try again with next official release from ARM
-        xpm install --global @xpack-dev-tools/arm-none-eabi-gcc@9.3.1-1.1.1
-        echo `echo $HOME/.local/xPacks/@xpack-dev-tools/arm-none-eabi-gcc/*/.content/bin` >> $GITHUB_PATH
     
     - name: Build
       run: |
@@ -93,7 +109,7 @@ jobs:
     - name: Linker Map
       run: make BOARD=${{ matrix.board }} linkermap
       
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.board }}
         path: _bin/${{ matrix.board }}

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -60,13 +60,11 @@ jobs:
     steps:
     - name: Setup Python
       uses: actions/setup-python@v3
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v1
       
     - name: Checkout Code
       uses: actions/checkout@v3
       with:
+        fetch-depth: 0
         submodules: true
 
     - name: Checkout linkermap


### PR DESCRIPTION
fix #265 
- update action script
- use toolchain cache instead of node xpm
- also update gcc from 9.3.1 to 10.2.1