### PR TITLE
Adds support for the Challenger 840 BLE board

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -34,6 +34,7 @@ jobs:
           - 'bast_ble'
           - 'bluemicro_nrf52833'
           - 'bluemicro_nrf52840'
+          - 'challenger_840_ble'
           - 'ebyte_e104_bt5032a'
           - 'ebyte_e73_tbb'
           - 'electronut_labs_papyr'
@@ -60,6 +61,7 @@ jobs:
     steps:
     - name: Setup Python
       uses: actions/setup-python@v3
+
       
     - name: Checkout Code
       uses: actions/checkout@v3
@@ -97,6 +99,7 @@ jobs:
       run: |
         pip3 install adafruit-nrfutil uritemplate requests intelhex
         pip3 install linkermap/
+
     
     - name: Build
       run: |
@@ -105,6 +108,7 @@ jobs:
 
     - name: Linker Map
       run: make BOARD=${{ matrix.board }} linkermap
+
       
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -62,7 +62,6 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v3
 
-      
     - name: Checkout Code
       uses: actions/checkout@v3
       with:
@@ -100,7 +99,6 @@ jobs:
         pip3 install adafruit-nrfutil uritemplate requests intelhex
         pip3 install linkermap/
 
-    
     - name: Build
       run: |
         make BOARD=${{ matrix.board }} all
@@ -109,7 +107,6 @@ jobs:
     - name: Linker Map
       run: make BOARD=${{ matrix.board }} linkermap
 
-      
     - uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.board }}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This is a CDC/DFU/UF2 bootloader for nRF52 boards.
 - Adafruit Metro nRF52840 Express
 - [Akizukidenshi AE-BL652-BO](https://akizukidenshi.com/catalog/g/gK-15567/)
 - [Electronut Labs Papyr](https://docs.electronut.in/papyr/)
+- [iLabs Challenger 840 BLE](https://ilabs.se/challenger-840-ble-datasheet/)
 - [MakerDiary MDK nRF52840 USB Dongle](https://makerdiary.com/products/nrf52840-mdk-usb-dongle)
 - [MakerDiary nRF52840 M.2 Module](https://makerdiary.com/products/nrf52840-m2-module)
 - [Nordic nRF52840DK PCA10056](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK)
@@ -79,7 +80,7 @@ For other boards, please check the board definition for details.
 
 ### Making your own UF2
 
-To create your own UF2 DFU update image, simply use the [Python conversion script](https://github.com/Microsoft/uf2/blob/master/utils/uf2conv.py) on a .bin file or .hex file, specifying the family as **0xADA52840** (nRF52840) or **0x621E937A** (nRF52833). 
+To create your own UF2 DFU update image, simply use the [Python conversion script](https://github.com/Microsoft/uf2/blob/master/utils/uf2conv.py) on a .bin file or .hex file, specifying the family as **0xADA52840** (nRF52840) or **0x621E937A** (nRF52833).
 
 ```
 nRF52840
@@ -202,4 +203,3 @@ pip install intelhex
 
 Make sure that `nrfjprog` is available from the command-line. This binary is
 part of Nordic's nRF5x Command Line Tools.
-

--- a/src/boards/boards.c
+++ b/src/boards/boards.c
@@ -62,6 +62,8 @@ bool button_pressed(uint32_t pin)
   return nrf_gpio_pin_read(pin) == active_state;
 }
 
+// This is declared so that a board specific init can be called from here.
+void __attribute__((weak)) extern_board_init(void) { }
 void board_init(void)
 {
   // stop LF clock just in case we jump from application without reset
@@ -93,6 +95,8 @@ void board_init(void)
 #if ENABLE_DCDC_1 == 1
   NRF_POWER->DCDCEN = 1;
 #endif
+  // Make sure any custom inits are performed
+  extern_board_init();
 
 // When board is supplied on VDDH (and not VDD), this specifies what voltage the GPIO should run at
 // and what voltage is output at VDD. The default (0xffffffff) is 1.8V; typically you'll want

--- a/src/boards/boards.c
+++ b/src/boards/boards.c
@@ -63,7 +63,7 @@ bool button_pressed(uint32_t pin)
 }
 
 // This is declared so that a board specific init can be called from here.
-void __attribute__((weak)) extern_board_init(void) { }
+void __attribute__((weak)) board_init_extra(void) { }
 void board_init(void)
 {
   // stop LF clock just in case we jump from application without reset

--- a/src/boards/boards.c
+++ b/src/boards/boards.c
@@ -96,7 +96,7 @@ void board_init(void)
   NRF_POWER->DCDCEN = 1;
 #endif
   // Make sure any custom inits are performed
-  extern_board_init();
+  board_init_extra();
 
 // When board is supplied on VDDH (and not VDD), this specifies what voltage the GPIO should run at
 // and what voltage is output at VDD. The default (0xffffffff) is 1.8V; typically you'll want

--- a/src/boards/challenger_840_ble/board.h
+++ b/src/boards/challenger_840_ble/board.h
@@ -1,0 +1,73 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ha Thach for Adafruit Industries, 2022 Invector Labs
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef _CHALLENGER_840_BLE_H
+#define _CHALLENGER_840_BLE_H
+
+#define _PINNUM(port, pin)    ((port)*32 + (pin))
+
+/*------------------------------------------------------------------*/
+/* LED
+ *------------------------------------------------------------------*/
+#define LEDS_NUMBER           1
+#define LED_PRIMARY_PIN       _PINNUM(0, 12)
+#define LED_STATE_ON          1
+
+#define LED_NEOPIXEL           _PINNUM(1, 8)
+#define NEOPIXELS_NUMBER      1
+#define BOARD_RGB_BRIGHTNESS  0x040404
+
+/*------------------------------------------------------------------*/
+/* BUTTON
+ *------------------------------------------------------------------*/
+#define BUTTONS_NUMBER        2
+#define BUTTON_1              _PINNUM(0, 19)
+#define BUTTON_2              _PINNUM(0, 8)  // Pulls flash cs high
+#define BUTTON_PULL           NRF_GPIO_PIN_PULLUP
+
+/*------------------------------------------------------------------*/
+/* On board LDO control
+ *------------------------------------------------------------------*/
+#define LDO_CONTROL_PIN       _PINNUM(1, 9)  // Enables external pwr
+
+//--------------------------------------------------------------------+
+// BLE OTA
+//--------------------------------------------------------------------+
+#define BLEDIS_MANUFACTURER   "Invector Labs"
+#define BLEDIS_MODEL          "Challenger 840 BLE"
+
+//--------------------------------------------------------------------+
+// USB
+//--------------------------------------------------------------------+
+#define USB_DESC_VID           0x1209
+#define USB_DESC_UF2_PID       0x7380
+#define USB_DESC_CDC_ONLY_PID  0x7381
+
+//------------- UF2 -------------//
+#define UF2_PRODUCT_NAME      "ILabs Challenger 840"
+#define UF2_VOLUME_LABEL      "CH840BOOT"
+#define UF2_BOARD_ID          "nRF52840-Challenger-840"
+#define UF2_INDEX_URL         "https://www.ilabs.se"
+
+#endif // _CHALLENGER_840_BLE_H

--- a/src/boards/challenger_840_ble/board.mk
+++ b/src/boards/challenger_840_ble/board.mk
@@ -1,0 +1,1 @@
+MCU_SUB_VARIANT = nrf52840

--- a/src/boards/challenger_840_ble/pinconfig.c
+++ b/src/boards/challenger_840_ble/pinconfig.c
@@ -1,0 +1,27 @@
+#include "boards.h"
+#include "board.h"
+#include "uf2/configkeys.h"
+
+__attribute__((used, section(".bootloaderConfig")))
+const uint32_t bootloaderConfig[] =
+{
+  /* CF2 START */
+  CFG_MAGIC0, CFG_MAGIC1,                       // magic
+  5, 100,                                       // used entries, total entries
+
+  204, 0x100000,                                // FLASH_BYTES = 0x100000
+  205, 0x40000,                                 // RAM_BYTES = 0x40000
+  208, (USB_DESC_VID << 16) | USB_DESC_UF2_PID, // BOOTLOADER_BOARD_ID = USB VID+PID, used for verification when updating bootloader via uf2
+  209, 0xada52840,                              // UF2_FAMILY = 0xada52840
+  210, 0x20,                                    // PINS_PORT_SIZE = PA_32
+
+  0, 0, 0, 0, 0, 0, 0, 0
+  /* CF2 END */
+};
+
+void extern_board_init(void)
+{
+  // Turn LDO on
+  nrf_gpio_cfg_output(LDO_CONTROL_PIN);
+  nrf_gpio_pin_write(LDO_CONTROL_PIN, 1);
+}

--- a/src/boards/challenger_840_ble/pinconfig.c
+++ b/src/boards/challenger_840_ble/pinconfig.c
@@ -19,7 +19,7 @@ const uint32_t bootloaderConfig[] =
   /* CF2 END */
 };
 
-void extern_board_init(void)
+void board_init_extra(void)
 {
   // Turn LDO on
   nrf_gpio_cfg_output(LDO_CONTROL_PIN);


### PR DESCRIPTION
This PR adds support for the Challenger 840 BLE board.
It also adds the possibility to add a board specific initialization function (extern_board_init()) to the board specific files. This is done by having a weak declared function in boards.c that can be overridden by the board specific files.