### PR TITLE
fix 'array subscript 0 is outside array bounds' for newer gcc versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,6 +323,11 @@ ifeq ($(DEBUG), 1)
   C_SRC += $(RTT_SRC)/RTT/SEGGER_RTT.c
 endif
 
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
+ifneq ($(findstring 12.,$(shell $(CC) --version 2>/dev/null)),)
+	CFLAGS += --param=min-pagesize=0
+endif
+
 #------------------------------------------------------------------------------
 # Linker Flags
 #------------------------------------------------------------------------------


### PR DESCRIPTION
I'm got the following error when building:

`
lib/sdk11/components/libraries/bootloader_dfu/bootloader_settings.c: In function 'bootloader_mbr_addrs_populate':
lib/sdk11/components/libraries/bootloader_dfu/bootloader_settings.c:45:7: error: array subscript 0 is outside array bounds of 'const uint
32_t[0]' {aka 'const long unsigned int[]'} [-Werror=array-bounds]
   45 |   if (*(const uint32_t *)MBR_BOOTLOADER_ADDR == 0xFFFFFFFF)
compilation terminated due to -Wfatal-errors.
cc1: all warnings being treated as errors
make: *** [Makefile:393: _build/build-feather_nrf52840_express/bootloader_settings.o] Error 1
`

Looked around and found this issue over at QMK: https://github.com/qmk/qmk_firmware/issues/17064
The main bug referenced can be found here: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523

In essence: gcc versions of 12 and above have a regression bug that can be solved by adding the compile flag `--param=min-pagesize=0`. The surrounding conditional in the commit checks that the flag is supported. (Small adaptations to QMKs fix really; https://github.com/qmk/qmk_firmware/pull/17136/commits/216081043649567fb387f9a9c4cc108ae78f1736)

Anyway, building works well for me with this minor change.