### PR TITLE
Support for no button

### DIFF
--- a/src/boards/boards.c
+++ b/src/boards/boards.c
@@ -44,6 +44,9 @@
 #endif
 
 //------------- IMPLEMENTATION -------------//
+
+#if defined(BUTTON_DFU) || defined(BUTTON_FRESET)
+
 void button_init(uint32_t pin)
 {
   if ( BUTTON_PULL == NRF_GPIO_PIN_PULLDOWN )
@@ -62,6 +65,8 @@ bool button_pressed(uint32_t pin)
   return nrf_gpio_pin_read(pin) == active_state;
 }
 
+#endif
+
 // This is declared so that a board specific init can be called from here.
 void __attribute__((weak)) board_init_extra(void) { }
 void board_init(void)
@@ -73,8 +78,12 @@ void board_init(void)
   NRF_CLOCK->LFCLKSRC = CLOCK_LFCLKSRC_SRC_RC;
   NRF_CLOCK->TASKS_LFCLKSTART = 1UL;
 
+#ifdef BUTTON_DFU
   button_init(BUTTON_DFU);
+#endif
+#ifdef BUTTON_FRESET
   button_init(BUTTON_FRESET);
+#endif
   NRFX_DELAY_US(100); // wait for the pin state is stable
 
 #if LEDS_NUMBER > 0

--- a/src/boards/boards.h
+++ b/src/boards/boards.h
@@ -37,11 +37,11 @@
 #define UF2_VOLUME_LABEL   "NRF52BOOT  "
 #endif
 
-#ifndef BUTTON_DFU
+#if !defined(BUTTON_DFU) && defined(BUTTON_1)
 #define BUTTON_DFU      BUTTON_1
 #endif
 
-#ifndef BUTTON_FRESET
+#if !defined(BUTTON_FRESET) && defined(BUTTON_2)
 #define BUTTON_FRESET   BUTTON_2
 #endif
 
@@ -104,13 +104,11 @@ void led_tick(void);
 //--------------------------------------------------------------------+
 // BUTTONS
 //--------------------------------------------------------------------+
-// Make sure we have at least two buttons (DFU + FRESET since DFU+FRST=OTA)
-#if BUTTONS_NUMBER < 2
-#error "At least two buttons required in the BSP (see 'BUTTONS_NUMBER')"
-#endif
 
+#if defined(BUTTON_DFU) || defined(BUTTON_FRESET)
 void button_init(uint32_t pin);
 bool button_pressed(uint32_t pin);
+#endif
 
 bool is_ota(void);
 

--- a/src/main.c
+++ b/src/main.c
@@ -259,10 +259,14 @@ static void check_dfu_mode(void)
 
   /*------------- Determine DFU mode (Serial, OTA, FRESET or normal) -------------*/
   // DFU button pressed
+#if defined(BUTTON_DFU)
   dfu_start = dfu_start || button_pressed(BUTTON_DFU);
+#endif
 
   // DFU + FRESET are pressed --> OTA
+#if defined(BUTTON_DFU) && defined(BUTTON_FRESET)
   _ota_dfu = _ota_dfu  || ( button_pressed(BUTTON_DFU) && button_pressed(BUTTON_FRESET) ) ;
+#endif
 
   bool const valid_app = bootloader_app_is_valid();
   bool const just_start_app = valid_app && !dfu_start && (*dbl_reset_mem) == DFU_DBL_RESET_APP;


### PR DESCRIPTION
[Seeed Studio XIAO nRF52840](https://www.seeedstudio.com/Seeed-XIAO-BLE-nRF52840-p-5201.html) and [Sense](https://www.seeedstudio.com/Seeed-XIAO-BLE-Sense-nRF52840-p-5253.html) do not have buttons.
(Double-click Reset to transition to DFU.)