### PR TITLE
Set the default max MTU size within the DFU transport to 23

### DIFF
--- a/lib/sdk11/components/libraries/bootloader_dfu/dfu_transport_ble.c
+++ b/lib/sdk11/components/libraries/bootloader_dfu/dfu_transport_ble.c
@@ -37,7 +37,7 @@
 
 
 #define BLEGAP_EVENT_LENGTH             6
-#define BLEGATT_ATT_MTU_MAX             247
+#define BLEGATT_ATT_MTU_MAX             23
 enum { BLE_CONN_CFG_HIGH_BANDWIDTH = 1 };
 
 #define DFU_REV_MAJOR                        0x00                                                    /** DFU Major revision number to be exposed. */


### PR DESCRIPTION
Changed the default max MTU size within the DFU transport to 23, which is the required size for the legacy bootloader to perform a successful OTA with the latest Nordic-DFU-Library. This resolves #287.