### PR TITLE
Add `board_init2` and `board_teardown2`

### DIFF
--- a/src/boards/boards.c
+++ b/src/boards/boards.c
@@ -63,7 +63,8 @@ bool button_pressed(uint32_t pin)
 }
 
 // This is declared so that a board specific init can be called from here.
-void __attribute__((weak)) board_init_extra(void) { }
+void __attribute__((weak)) board_init2(void) { }
+
 void board_init(void)
 {
   // stop LF clock just in case we jump from application without reset
@@ -96,7 +97,7 @@ void board_init(void)
   NRF_POWER->DCDCEN = 1;
 #endif
   // Make sure any custom inits are performed
-  board_init_extra();
+  board_init2();
 
 // When board is supplied on VDDH (and not VDD), this specifies what voltage the GPIO should run at
 // and what voltage is output at VDD. The default (0xffffffff) is 1.8V; typically you'll want
@@ -129,6 +130,9 @@ void board_init(void)
   SysTick_Config(SystemCoreClock/1000);
 }
 
+// Actions at the end of board_teardown.
+void __attribute__((weak)) board_teardown2(void) { }
+
 void board_teardown(void)
 {
   // Disable systick, turn off LEDs
@@ -159,6 +163,9 @@ void board_teardown(void)
   {
     nrf_gpio_cfg_default(i);
   }
+
+  // board specific teardown actions
+  board_teardown2();
 }
 
 static uint32_t _systick_count = 0;

--- a/src/boards/challenger_840_ble/pinconfig.c
+++ b/src/boards/challenger_840_ble/pinconfig.c
@@ -19,7 +19,7 @@ const uint32_t bootloaderConfig[] =
   /* CF2 END */
 };
 
-void board_init_extra(void)
+void board_init2(void)
 {
   // Turn LDO on
   nrf_gpio_cfg_output(LDO_CONTROL_PIN);


### PR DESCRIPTION
This also replace `board_init_extra`.

#301 

Wondering where to put `board_init2`, current location or the end of `board_init`.

I was going to add `board_init0` at the beginning of `board_init`, but found it's not necessary for M60.