### PR TITLE
Adds support for the Makerdiary nRF52840 Connect Kit board

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -45,7 +45,7 @@ jobs:
           - 'mikoto'
           - 'nice_nano'
           - 'nrf52840_bboard'
-          - 'nrf52840-connectkit'
+          - 'nRF52840_connect_kit'
           - 'nrf52840_m2'
           - 'ohs2020_badge'
           - 'particle_argon'

--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -45,6 +45,7 @@ jobs:
           - 'mikoto'
           - 'nice_nano'
           - 'nrf52840_bboard'
+          - 'nrf52840-connectkit'
           - 'nrf52840_m2'
           - 'ohs2020_badge'
           - 'particle_argon'

--- a/src/boards/nRF52840_connect_kit/board.h
+++ b/src/boards/nRF52840_connect_kit/board.h
@@ -1,0 +1,71 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Yihui Xiong for Makerdiary
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef _MAKERDIARY_NRF82540_CONNECT_KIT_H_
+#define _MAKERDIARY_NRF82540_CONNECT_KIT_H_
+
+#define _PINNUM(port, pin)    ((port)*32 + (pin))
+
+/*------------------------------------------------------------------*/
+/* LED
+ *------------------------------------------------------------------*/
+#define LEDS_NUMBER           1
+#define LED_PRIMARY_PIN       _PINNUM(1, 15)  // Green
+#define LED_STATE_ON          0
+
+#define LED_RGB_RED_PIN       _PINNUM(1, 10)
+#define LED_RGB_GREEN_PIN     _PINNUM(1, 11)
+#define LED_RGB_BLUE_PIN      _PINNUM(1, 12)
+#define BOARD_RGB_BRIGHTNESS  0x404040
+/*------------------------------------------------------------------*/
+/* BUTTON
+ *------------------------------------------------------------------*/
+#define BUTTONS_NUMBER        2
+#define BUTTON_1              _PINNUM(1, 0)  // P1.00: User Button
+#define BUTTON_2              _PINNUM(1, 7)  // P1.07: NC
+#define BUTTON_PULL           NRF_GPIO_PIN_PULLUP
+
+//--------------------------------------------------------------------+
+// BLE OTA
+//--------------------------------------------------------------------+
+#define BLEDIS_MANUFACTURER   "Makerdiary"
+#define BLEDIS_MODEL          "nRF52840 Connect Kit"
+
+//--------------------------------------------------------------------+
+// USB
+//--------------------------------------------------------------------+
+#define USB_DESC_VID            0x2886
+#define USB_DESC_UF2_PID        0xF00E
+#define USB_DESC_CDC_ONLY_PID   0xF00E
+
+//--------------------------------------------------------------------+
+// UF2
+//--------------------------------------------------------------------+
+#define UF2_PRODUCT_NAME        "nRF52840 Connect Kit"
+#define UF2_VOLUME_LABEL        "CONNECTKIT"
+#define UF2_BOARD_ID            "CONNECTKIT"
+#define UF2_INDEX_URL           "https://wiki.makerdiary.com/nrf52840-connectkit/"
+
+
+#endif /* _MAKERDIARY_NRF82540_CONNECT_KIT_H_ */

--- a/src/boards/nRF52840_connect_kit/board.h
+++ b/src/boards/nRF52840_connect_kit/board.h
@@ -64,7 +64,7 @@
 //--------------------------------------------------------------------+
 #define UF2_PRODUCT_NAME        "nRF52840 Connect Kit"
 #define UF2_VOLUME_LABEL        "CONNECTKIT"
-#define UF2_BOARD_ID            "CONNECTKIT"
+#define UF2_BOARD_ID            "nRF52840-Connect-Kit"
 #define UF2_INDEX_URL           "https://wiki.makerdiary.com/nrf52840-connectkit/"
 
 

--- a/src/boards/nRF52840_connect_kit/board.h
+++ b/src/boards/nRF52840_connect_kit/board.h
@@ -56,8 +56,8 @@
 // USB
 //--------------------------------------------------------------------+
 #define USB_DESC_VID            0x2886
-#define USB_DESC_UF2_PID        0xF00E
-#define USB_DESC_CDC_ONLY_PID   0xF00E
+#define USB_DESC_UF2_PID        0xF00F
+#define USB_DESC_CDC_ONLY_PID   0xF00F
 
 //--------------------------------------------------------------------+
 // UF2

--- a/src/boards/nRF52840_connect_kit/board.mk
+++ b/src/boards/nRF52840_connect_kit/board.mk
@@ -1,0 +1,2 @@
+MCU_SUB_VARIANT = nrf52840
+USE_NFCT = yes

--- a/src/boards/nRF52840_connect_kit/pinconfig.c
+++ b/src/boards/nRF52840_connect_kit/pinconfig.c
@@ -1,0 +1,19 @@
+#include "boards.h"
+#include "uf2/configkeys.h"
+
+__attribute__((used, section(".bootloaderConfig")))
+const uint32_t bootloaderConfig[] =
+{
+  /* CF2 START */
+  CFG_MAGIC0, CFG_MAGIC1,                       // magic
+  5, 100,                                       // used entries, total entries
+
+  204, 0x100000,                                // FLASH_BYTES = 0x100000
+  205, 0x40000,                                 // RAM_BYTES = 0x40000
+  208, (USB_DESC_VID << 16) | USB_DESC_UF2_PID, // BOOTLOADER_BOARD_ID = USB VID+PID, used for verification when updating bootloader via uf2
+  209, 0xada52840,                              // UF2_FAMILY = 0xada52840
+  210, 0x20,                                    // PINS_PORT_SIZE = PA_32
+
+  0, 0, 0, 0, 0, 0, 0, 0
+  /* CF2 END */
+};


### PR DESCRIPTION
This PR adds support for the Makerdiary nRF52840 Connect Kit board.

Matches the format of the existing Makerdiary Pitaya Go board

https://github.com/adafruit/Adafruit_nRF52_Bootloader/blob/master/src/boards/pitaya_go/board.h