### PR TITLE
add & enable DISPLAY_VSENSOR_PIN if available (required for sense tft)

### DIFF
--- a/src/boards/boards.c
+++ b/src/boards/boards.c
@@ -250,6 +250,11 @@ void board_display_init(void) {
   //------------- Display Init -------------//
   nrf_gpio_cfg_output(DISPLAY_PIN_DC);
 
+#if defined(DISPLAY_VSENSOR_PIN) && DISPLAY_VSENSOR_PIN >= 0
+  nrf_gpio_cfg_output(DISPLAY_VSENSOR_PIN);
+  nrf_gpio_pin_write(DISPLAY_VSENSOR_PIN, DISPLAY_VSENSOR_ON);
+#endif
+
 #if defined(DISPLAY_PIN_RST) && DISPLAY_PIN_RST >= 0
   nrf_gpio_cfg_output(DISPLAY_PIN_RST);
   nrf_gpio_pin_clear(DISPLAY_PIN_RST);

--- a/src/boards/feather_nrf52840_sense_tft/board.h
+++ b/src/boards/feather_nrf52840_sense_tft/board.h
@@ -50,6 +50,11 @@
 //--------------------------------------------------------------------+
 // Display
 //--------------------------------------------------------------------+
+
+// VSensor required to power the display
+#define DISPLAY_VSENSOR_PIN   _PINNUM(1, 7)
+#define DISPLAY_VSENSOR_ON    1
+
 #define DISPLAY_CONTROLLER_ST7789
 
 #define DISPLAY_PIN_SCK       _PINNUM(0, 26)


### PR DESCRIPTION
## Description of Change

Sense TFT required VSensor pin to be enabled for display (and other on-board peripherals).

![image](https://github.com/adafruit/Adafruit_nRF52_Bootloader/assets/249515/4006f57d-4b2b-4701-94f2-c204959667b9)


