### PR TITLE
fix compilation issue 'array subscript 0 is outside array bounds' for arm-none-eabi-gcc version 13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,7 +342,8 @@ endif
 CFLAGS += -DDFU_APP_DATA_RESERVED=$(DFU_APP_DATA_RESERVED)
 
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
-ifneq ($(findstring 12.,$(shell $(CC) --version 2>/dev/null)),)
+# Fixes for gcc version 12 and 13.
+ifneq (,$(filter 12.% 13.%,$(shell $(CC) -dumpversion 2>/dev/null)))
 	CFLAGS += --param=min-pagesize=0
 endif
 


### PR DESCRIPTION
Hello!  :D
I got the following error when building with `arm-none-eabi-gcc` version `13.2.0`, in Linux `5.15.146-1-MANJARO`:

```
lib/sdk11/components/libraries/bootloader_dfu/bootloader_settings.c: In function 'bootloader_mbr_addrs_populate':
lib/sdk11/components/libraries/bootloader_dfu/bootloader_settings.c:45:7: error: array subscript 0 is outside array bounds of 'const uint32_t[0]' {aka 'const long unsigned int[]'} [-Werror=array-bounds=]
   45 |   if (*(const uint32_t *)MBR_BOOTLOADER_ADDR == 0xFFFFFFFF)
compilation terminated due to -Wfatal-errors.
cc1: all warnings being treated as errors
make: *** [Makefile:417: _build/build-sparkfun_nrf52840_micromod/bootloader_settings.o] Error 1
```

It seems like this is an issue with newer GCC versions. Based on the discussion in #273: This was already fixed for GCC version 12, but the problem reappeared for GCC version 13.  

I tested the same fix proposed in #273 (add the compile flag `--param=min-pagesize=0`). It solved the issue, and I could successfully compile the bootloader firmware.

This PR is just an extension of the #273 fix. The conditional in the MakeFile now checks for both gcc versions 12 and 13 and applies the relevant compile flag. I tested the code against `arm-none-eabi-gcc` versions:
- `13.2.0`
- `12.2.Rel1`

It worked with both.

Thank you for your time!