### PR TITLE
Add support Murata MBN52832DK board

### DIFF
--- a/src/boards/mbn52832dk/board.h
+++ b/src/boards/mbn52832dk/board.h
@@ -1,0 +1,63 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ha Thach for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef _MBN52832DK_H
+#define _MBN52832DK_H
+
+/*------------------------------------------------------------------*/
+/* LED
+ *------------------------------------------------------------------*/
+#define LEDS_NUMBER        2
+#define LED_PRIMARY_PIN    17 // LED1
+#define LED_SECONDARY_PIN  18 // LED2
+#define LED_STATE_ON       1
+
+/*------------------------------------------------------------------*/
+/* BUTTON
+ *------------------------------------------------------------------*/
+#define BUTTONS_NUMBER     2
+#define BUTTON_1           13
+#define BUTTON_2           14
+#define BUTTON_PULL        NRF_GPIO_PIN_PULLUP
+
+/*------------------------------------------------------------------*/
+/* UART (only used by nRF52832)
+ *------------------------------------------------------------------*/
+#define RX_PIN_NUMBER      8
+#define TX_PIN_NUMBER      6
+#define CTS_PIN_NUMBER     0
+#define RTS_PIN_NUMBER     0
+#define HWFC               false
+
+//--------------------------------------------------------------------+
+// BLE OTA
+//--------------------------------------------------------------------+
+#define BLEDIS_MANUFACTURER "Murata"
+#define BLEDIS_MODEL        "MBN52832DK"
+
+#define UF2_BOARD_ID        "nRF52832-MBN52832DK-v1"
+#define UF2_PRODUCT_NAME    "Murata MBN52832DK"
+#define UF2_INDEX_URL       "https://www.murata.com/ja-jp/products/connectivitymodule/bluetooth/overview/lineup/mbn52832"
+
+#endif // _MBN52832DK_H

--- a/src/boards/mbn52832dk/board.mk
+++ b/src/boards/mbn52832dk/board.mk
@@ -1,0 +1,2 @@
+# nrf52 is nrf52832
+MCU_SUB_VARIANT = nrf52


### PR DESCRIPTION
## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [x] Please provide specific title of the PR describing the change
- [x] If you are adding an new boards, please make sure
  - [x] Provide link to your allocated VID/PID if applicable (This borad has no USB)
  - [x] `UF2_BOARD_ID` in your board.h follow correct format from [uf2 specs](https://github.com/microsoft/uf2#files-exposed-by-bootloaders)

*This checklist items that are not applicable to your PR can be deleted.*

-----------

## Description of Change

Added support for Murata MBN52832DK board.

https://www.murata.com/ja-jp/products/connectivitymodule/bluetooth/overview/lineup/mbn52832

