### PR TITLE
Adding Omnimo board

### DIFF
--- a/src/boards/omnimo_nrf52840/board.cmake
+++ b/src/boards/omnimo_nrf52840/board.cmake
@@ -1,0 +1,1 @@
+set(MCU_VARIANT nrf52840)

--- a/src/boards/omnimo_nrf52840/board.h
+++ b/src/boards/omnimo_nrf52840/board.h
@@ -1,0 +1,72 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ha Thach for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef _OMNIMO_NRF52840_H
+#define _OMNIMO_NRF52840_H
+
+#define _PINNUM(port, pin)    ((port)*32 + (pin))
+
+/*------------------------------------------------------------------*/
+/* LED
+ *------------------------------------------------------------------*/
+#define LEDS_NUMBER           2
+#define LED_PRIMARY_PIN       _PINNUM(1, 15)
+#define LED_SECONDARY_PIN     _PINNUM(1, 10)
+#define LED_STATE_ON          1
+
+#define LED_NEOPIXEL          _PINNUM(0, 16)
+
+#define NEOPIXELS_NUMBER      1
+#define BOARD_RGB_BRIGHTNESS  0x040404
+
+/*------------------------------------------------------------------*/
+/* BUTTON
+ *------------------------------------------------------------------*/
+#define BUTTONS_NUMBER        2
+#define BUTTON_1              _PINNUM(1, 02)
+#define BUTTON_2              _PINNUM(1, 07) 
+#define BUTTON_PULL           NRF_GPIO_PIN_PULLUP
+
+//--------------------------------------------------------------------+
+// BLE OTA
+//--------------------------------------------------------------------+
+#define BLEDIS_MANUFACTURER   "eAFAQ"
+#define BLEDIS_MODEL          "OMNIMO nRF52840"
+
+//--------------------------------------------------------------------+
+// USB
+//--------------------------------------------------------------------+
+
+//Shared VID/PID with pca10056 
+#define USB_DESC_VID           0x239A
+#define USB_DESC_UF2_PID       0x00DA
+#define USB_DESC_CDC_ONLY_PID  0x00DA
+
+//------------- UF2 -------------//
+#define UF2_PRODUCT_NAME      "Omnimo nRF52840"
+#define UF2_VOLUME_LABEL      "OMNIn52BOOT"
+#define UF2_BOARD_ID          "nRF52840-Omnimo"
+#define UF2_INDEX_URL         "https://www.crowdsupply.com/eafaq/omnimo-nrf52840"
+
+#endif // _OMNIMO_NRF52840_H

--- a/src/boards/omnimo_nrf52840/board.h
+++ b/src/boards/omnimo_nrf52840/board.h
@@ -59,9 +59,9 @@
 //--------------------------------------------------------------------+
 
 //Shared VID/PID with pca10056 
-#define USB_DESC_VID           0x239A
-#define USB_DESC_UF2_PID       0x00DA
-#define USB_DESC_CDC_ONLY_PID  0x00DA
+#define USB_DESC_VID           0x1209
+#define USB_DESC_UF2_PID       0xCECE
+#define USB_DESC_CDC_ONLY_PID  0xCECE
 
 //------------- UF2 -------------//
 #define UF2_PRODUCT_NAME      "Omnimo nRF52840"

--- a/src/boards/omnimo_nrf52840/board.mk
+++ b/src/boards/omnimo_nrf52840/board.mk
@@ -1,0 +1,1 @@
+MCU_SUB_VARIANT = nrf52840

--- a/src/boards/omnimo_nrf52840/pinconfig.c
+++ b/src/boards/omnimo_nrf52840/pinconfig.c
@@ -1,0 +1,19 @@
+#include "boards.h"
+#include "uf2/configkeys.h"
+
+__attribute__((used, section(".bootloaderConfig")))
+const uint32_t bootloaderConfig[] =
+{
+  /* CF2 START */
+  CFG_MAGIC0, CFG_MAGIC1,                       // magic
+  5, 100,                                       // used entries, total entries
+
+  204, 0x100000,                                // FLASH_BYTES = 0x100000
+  205, 0x40000,                                 // RAM_BYTES = 0x40000
+  208, (USB_DESC_VID << 16) | USB_DESC_UF2_PID, // BOOTLOADER_BOARD_ID = USB VID+PID, used for verification when updating bootloader via uf2
+  209, 0xada52840,                              // UF2_FAMILY = 0xada52840
+  210, 0x20,                                    // PINS_PORT_SIZE = PA_32
+
+  0, 0, 0, 0, 0, 0, 0, 0
+  /* CF2 END */
+};


### PR DESCRIPTION
Omnimo (https://www.crowdsupply.com/eafaq/omnimo-nrf52840) is a new series of compact, all-in-one, and easy-to-use development boards that support several types of add-on modules. Thanks to its innovative pin and port positioning, Omnimo integrates various module sockets, including mikroBUS, Feather, Pmod, and Qwiic/Stemma QT, making it the most compact board capable of hosting over 2,000 different modules already available on the market.



## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [ ] Please provide specific title of the PR describing the change
- [ ] If you are adding an new boards, please make sure
  - [ ] Provide link to your allocated VID/PID if applicable
  - [ ] `UF2_BOARD_ID` in your board.h follow correct format from [uf2 specs](https://github.com/microsoft/uf2#files-exposed-by-bootloaders)

*This checklist items that are not applicable to your PR can be deleted.*

-----------

## Description of Change

Please describe your proposed Pull Request and it's impact.
