### PR TITLE
Correct a comment about overriding the SD_VERSION in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ set(UF2_FAMILY_ID_BOOTLOADER 0xd663823c)
 set(CMAKE_EXECUTABLE_SUFFIX .elf)
 add_executable(bootloader)
 
-# SD_VERSION can be overwritten by board.cmake
+# SD_VERSION can be overwritten by board.mk
 if(NOT DEFINED SD_VERSION)
   if(MCU_VARIANT STREQUAL "nrf52833")
     set(SD_VERSION 7.3.0)


### PR DESCRIPTION
All existing boards that override SD_VERSION do it in board.mk and, at least, my naive attempt to do it in board.cmake didn't actually work.

## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [x] Please provide specific title of the PR describing the change

*This checklist items that are not applicable to your PR can be deleted.*

-----------

## Description of Change

A doc change to help folks getting started with softdevice version customization.
