### PR TITLE
fix: CMake build producing too large binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,10 @@ set(TINYUSB_DIR ${CMAKE_CURRENT_LIST_DIR}/lib/tinyusb/src)
 set(UF2CONV_PY ${CMAKE_CURRENT_LIST_DIR}/lib/uf2/utils/uf2conv.py)
 set(UF2_FAMILY_ID_BOOTLOADER 0xd663823c)
 
+if (NOT DEFINED CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
+  set(CMAKE_BUILD_TYPE MinSizeRel CACHE STRING "Build type" FORCE)
+endif ()
+
 #-------------------
 # Bootloader
 #-------------------
@@ -131,7 +135,6 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   target_include_directories(bootloader PUBLIC
     lib/SEGGER_RTT/RTT
     )
-
   target_compile_definitions(bootloader PUBLIC
     CFG_DEBUG
     SEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL
@@ -170,12 +173,12 @@ target_compile_options(bootloader PUBLIC
   -Wmissing-format-attribute
   -Wno-endif-labels
   -Wunreachable-code
-  -Os
   # Suppress warning caused by SDK
   -Wno-unused-parameter -Wno-expansion-to-defined -Wno-array-bounds
   )
 target_compile_definitions(bootloader PUBLIC
   SOFTDEVICE_PRESENT
+  CONFIG_GPIO_AS_PINRESET
   )
 
 if (TRACE_ETM STREQUAL "1")
@@ -335,3 +338,10 @@ add_custom_target(flash-mbr
 add_custom_target(flash-erase
   COMMAND ${NRFJPROG} -f nrf52 --eraseall
   )
+
+# flash skip crc magic ( app valid = 0x0001, crc = 0x0000 )
+#add_custom_target(flash-skip-crc
+#  #COMMAND ${NRFJPROG} --memwr $(BOOT_SETTING_ADDR) --val 0x00000001 -f nrf52
+#  COMMAND ${NRFJPROG} --memwr 0xFF000 --val 0x00000001 -f nrf52
+#  #COMMAND ${NRFJPROG} --memwr 0x7F000 --val 0x00000001 -f nrf52
+#  )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ target_compile_options(bootloader PUBLIC
   -Wmissing-format-attribute
   -Wno-endif-labels
   -Wunreachable-code
+  -Os
   # Suppress warning caused by SDK
   -Wno-unused-parameter -Wno-expansion-to-defined -Wno-array-bounds
   )

--- a/README.md
+++ b/README.md
@@ -114,14 +114,20 @@ You must have have a J-Link available to "unbrick" your device.
 
 ### Build:
 
-Firstly clone this repo with following commands
+Firstly clone this repo including its submodules with following command:
 
+```
+git clone --recurse-submodules -j8 https://github.com/adafruit/Adafruit_nRF52_Bootloader
+```
+
+For git versions before `2.13.0` you have to do that manually:
 ```
 git clone https://github.com/adafruit/Adafruit_nRF52_Bootloader
 cd Adafruit_nRF52_Bootloader
 git submodule update --init
 ```
 
+#### Build using `make`
 Then build it with `make BOARD={board} all`, for example:
 
 ```
@@ -136,6 +142,21 @@ You must provide a BOARD parameter with 'BOARD='
 Supported boards are: feather_nrf52840_express feather_nrf52840_express pca10056
 Makefile:90: *** BOARD not defined.  Stop
 ```
+
+#### Build using `cmake`
+
+Firstly initialize your build environment by passing your board to `cmake` via `-DBOARD={board}`:
+```
+cmake -DBOARD=feather_nrf52840_express -S . -B _build -GNinja
+```
+
+And then build it with:
+```
+cd _build
+ninja
+```
+
+You can also use the generator of your choice. For example omit the `-GNinja` and then you can invoke `make` from inside `_build` instead of `ninja`
 
 ### Flash
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ You must have have a J-Link available to "unbrick" your device.
 Firstly clone this repo including its submodules with following command:
 
 ```
-git clone --recurse-submodules -j8 https://github.com/adafruit/Adafruit_nRF52_Bootloader
+git clone --recurse-submodules https://github.com/adafruit/Adafruit_nRF52_Bootloader
 ```
 
 For git versions before `2.13.0` you have to do that manually:
@@ -146,17 +146,33 @@ Makefile:90: *** BOARD not defined.  Stop
 #### Build using `cmake`
 
 Firstly initialize your build environment by passing your board to `cmake` via `-DBOARD={board}`:
-```
-cmake -DBOARD=feather_nrf52840_express -S . -B _build -GNinja
+
+```bash
+mkdir build
+cd build
+cmake .. -DBOARD=feather_nrf52840_express 
 ```
 
 And then build it with:
-```
-cd _build
-ninja
+
+```bash
+make
 ```
 
-You can also use the generator of your choice. For example omit the `-GNinja` and then you can invoke `make` from inside `_build` instead of `ninja`
+You can also use the generator of your choice. For example adding the `-GNinja` and then you can invoke `ninja build` instead of `make`.
+
+To list all supported targets, run:
+
+```bash
+cmake --build . --target help
+``` 
+
+To build individual targets, you can specify it directly with `make` or using `cmake --build`:
+
+```bash
+make bootloader
+cmake --build . --target bootloader
+```
 
 ### Flash
 


### PR DESCRIPTION
## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [x] Please provide specific title of the PR describing the change

-----------

## Description of Change

This change will fix build errors with CMake as size optimization is missing and therefore it doesn't compile successfully. Also the documentation is extended to give a hint how to use CMake in this repository at all.
