### PR TITLE
fix: repair build with DEBUG=1 option

### DIFF
--- a/linker/nrf52833_debug.ld
+++ b/linker/nrf52833_debug.ld
@@ -1,7 +1,7 @@
 /* Linker script to configure memory regions. */
 
 SEARCH_DIR(.)
-GROUP(-lgcc -lc -lnosys)
+GROUP(-lgcc -lc)
 
 MEMORY
 {

--- a/linker/nrf52840_debug.ld
+++ b/linker/nrf52840_debug.ld
@@ -1,7 +1,7 @@
 /* Linker script to configure memory regions. */
 
 SEARCH_DIR(.)
-GROUP(-lgcc -lc -lnosys)
+GROUP(-lgcc -lc)
 
 MEMORY
 {

--- a/linker/nrf52_debug.ld
+++ b/linker/nrf52_debug.ld
@@ -1,7 +1,7 @@
 /* Linker script to configure memory regions. */
 
 SEARCH_DIR(.)
-GROUP(-lgcc -lc -lnosys)
+GROUP(-lgcc -lc)
 
 MEMORY
 {


### PR DESCRIPTION
## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [X] Please provide specific title of the PR describing the change

-----------

## Description of Change

The debug build with `DEBUG=1` option won't work as the retarget of the `printf` function to Segger RTT conflicts with the `libnosys.a` that is added in the debug linker scripts. This PR fixes this problem.