### PR TITLE
Add support for SparkFun Pro nRF52840 Mini

### DIFF
--- a/src/boards/sparkfun_nrf52840_mini/board.cmake
+++ b/src/boards/sparkfun_nrf52840_mini/board.cmake
@@ -1,0 +1,1 @@
+set(MCU_VARIANT nrf52840)

--- a/src/boards/sparkfun_nrf52840_mini/board.h
+++ b/src/boards/sparkfun_nrf52840_mini/board.h
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ha Thach for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef SPARKFUN_NRF52840_MINI_H
+#define SPARKFUN_NRF52840_MINI_H
+
+/*------------------------------------------------------------------*/
+/* LED
+ *------------------------------------------------------------------*/
+#define LEDS_NUMBER         2
+#define LED_PRIMARY_PIN     7
+#define LED_SECONDARY_PIN   14
+#define LED_STATE_ON        1
+
+/*------------------------------------------------------------------*/
+/* BUTTON
+ *------------------------------------------------------------------*/
+#define BUTTONS_NUMBER      2
+#define BUTTON_1            13
+#define BUTTON_2            17
+#define BUTTON_PULL         NRF_GPIO_PIN_PULLUP
+
+//--------------------------------------------------------------------+
+// BLE OTA
+//--------------------------------------------------------------------+
+#define BLEDIS_MANUFACTURER    "SparkFun"
+#define BLEDIS_MODEL           "Pro nRF52840 Mini"
+
+//--------------------------------------------------------------------+
+// USB
+//--------------------------------------------------------------------+
+
+#define USB_DESC_VID           0x1B4F
+#define USB_DESC_UF2_PID       0x0029
+#define USB_DESC_CDC_ONLY_PID  0x002A
+
+#define UF2_PRODUCT_NAME    "SparkFun Pro nRF52840 Mini"
+#define UF2_BOARD_ID        "nRF52840-Mini-v1"
+#define UF2_INDEX_URL       "https://www.sparkfun.com/sparkfun-pro-nrf52840-mini-bluetooth-development-board.html"
+
+#endif // SPARKFUN_NRF52840_MINI_H

--- a/src/boards/sparkfun_nrf52840_mini/board.mk
+++ b/src/boards/sparkfun_nrf52840_mini/board.mk
@@ -1,0 +1,1 @@
+MCU_SUB_VARIANT = nrf52840

--- a/src/boards/sparkfun_nrf52840_mini/pinconfig.c
+++ b/src/boards/sparkfun_nrf52840_mini/pinconfig.c
@@ -1,0 +1,19 @@
+#include "boards.h"
+#include "uf2/configkeys.h"
+
+__attribute__((used, section(".bootloaderConfig")))
+const uint32_t bootloaderConfig[] =
+{
+  /* CF2 START */
+  CFG_MAGIC0, CFG_MAGIC1,                       // magic
+  5, 100,                                       // used entries, total entries
+
+  204, 0x100000,                                // FLASH_BYTES = 0x100000
+  205, 0x40000,                                 // RAM_BYTES = 0x40000
+  208, (USB_DESC_VID << 16) | USB_DESC_UF2_PID, // BOOTLOADER_BOARD_ID = USB VID+PID, used for verification when updating bootloader via uf2
+  209, 0xada52840,                              // UF2_FAMILY = 0xada52840
+  210, 0x20,                                    // PINS_PORT_SIZE = PA_32
+
+  0, 0, 0, 0, 0, 0, 0, 0
+  /* CF2 END */
+};


### PR DESCRIPTION
## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [X] Please provide specific title of the PR describing the change
- [X] If you are adding an new boards, please make sure
  - [X] Provide link to your allocated VID/PID if applicable
  - [X]  `UF2_BOARD_ID` in your board.h follow correct format from [uf2 specs](https://github.com/microsoft/uf2#files-exposed-by-bootloaders)

*This checklist items that are not applicable to your PR can be deleted.*

-----------

## Description of Change

This is the spiritual successor of #62.

I started from the board definition of the PCA10056, which SparkFun says this board was based off of. Then, I copied over pin information [from definitions in their repo](https://github.com/sparkfun/nRF52840_Breakout_MDBT50Q/blob/46f154b42a57c1eed5dd1d212e41cef3c25b264b/Firmware/nRF5_SDK/components/boards/sparkfun_nrf52840_mini.h#L49-L69). To find the appropriate VID and PIDs, I looked at [the Arduino board definition](https://github.com/sparkfun/nRF52840_Breakout_MDBT50Q/blob/46f154b42a57c1eed5dd1d212e41cef3c25b264b/Firmware/Arduino/sparkfun_boards.txt#L7-L13).

There is only one switch aside from RST on the board, so I tied FRST to pin 17. The resultant bootloader gets into DFU mode correctly and the blue LED on the board breathes.
