### PR TITLE
fix: Fix build errors on GCC15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -392,12 +392,6 @@ endif
 
 CFLAGS += -DDFU_APP_DATA_RESERVED=$(DFU_APP_DATA_RESERVED)
 
-# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
-# Fixes for gcc version 12, 13, 14 and 15.
-ifneq (,$(filter 12.% 13.% 14.% 15.%,$(shell $(CC) -dumpversion 2>$(NULL_DEVICE))))
-	CFLAGS += --param=min-pagesize=0
-endif
-
 #------------------------------------------------------------------------------
 # Linker Flags
 #------------------------------------------------------------------------------

--- a/lib/sdk11/components/libraries/bootloader_dfu/bootloader_settings.c
+++ b/lib/sdk11/components/libraries/bootloader_dfu/bootloader_settings.c
@@ -42,6 +42,10 @@ void bootloader_util_settings_get(const bootloader_settings_t ** pp_bootloader_s
 
 void bootloader_mbr_addrs_populate(void)
 {
+#if defined(__GNUC__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
   if (*(const uint32_t *)MBR_BOOTLOADER_ADDR == 0xFFFFFFFF)
   {
     nrfx_nvmc_word_write(MBR_BOOTLOADER_ADDR, BOOTLOADER_REGION_START);
@@ -51,4 +55,7 @@ void bootloader_mbr_addrs_populate(void)
   {
     nrfx_nvmc_word_write(MBR_PARAM_PAGE_ADDR, BOOTLOADER_MBR_PARAMS_PAGE_ADDRESS);
   }
+#if defined(__GNUC__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic pop
+#endif
 }

--- a/src/usb/uf2/ghostfat.c
+++ b/src/usb/uf2/ghostfat.c
@@ -41,18 +41,18 @@
 //--------------------------------------------------------------------+
 
 // Add nonstring attribute if supported to avoid errors in GCC 15
-#ifdef __has_attribute
-    #define __NONSTRING__ __attribute__((nonstring))
+#if defined(__has_attribute) && __has_attribute(nonstring)
+  #define ATTR_NONSTRING __attribute__((nonstring))
 #else
-    #define __NONSTRING__
+  #define ATTR_NONSTRING
 #endif
 
 typedef struct {
     uint8_t JumpInstruction[3];
-    uint8_t OEMInfo[8] __NONSTRING__;
-    uint16_t SectorSize;
-    uint8_t SectorsPerCluster;
-    uint16_t ReservedSectors;
+  uint8_t  OEMInfo[8] ATTR_NONSTRING;
+  uint16_t SectorSize;
+  uint8_t  SectorsPerCluster;
+  uint16_t ReservedSectors;
     uint8_t FATCopies;
     uint16_t RootDirectoryEntries;
     uint16_t TotalSectors16;
@@ -66,8 +66,8 @@ typedef struct {
     uint8_t Reserved;
     uint8_t ExtendedBootSig;
     uint32_t VolumeSerialNumber;
-    uint8_t VolumeLabel[11] __NONSTRING__;
-    uint8_t FilesystemIdentifier[8] __NONSTRING__;
+    uint8_t  VolumeLabel[11] ATTR_NONSTRING;
+    uint8_t  FilesystemIdentifier[8] ATTR_NONSTRING;
 } __attribute__((packed)) FAT_BootBlock;
 
 typedef struct {
@@ -88,8 +88,8 @@ typedef struct {
 STATIC_ASSERT(sizeof(DirEntry) == 32);
 
 struct TextFile {
-  char const name[11] __NONSTRING__;
-  char const *content;
+  const char  name[11] ATTR_NONSTRING;
+  const char *content;
 };
 
 


### PR DESCRIPTION
## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [x] Please provide specific title of the PR describing the change


-----------

## Description of Change

Much like with GCC 12, 13 and 14 GCC 15 will throw array initialisation errors during compilation when performuing register accesses in bootloader_settings.c. GCC 15 also throws an error around the handling of string like non-string elements in ghostfat.c. This PR adds gcc 15 to the workaround versions in the makefile to fix the first error and adds a new nonstring define which resolves to blank if the attribute isn't available for the second
