### PR TITLE
Fix: reset wr_state on first block reception

### DIFF
--- a/src/usb/uf2/ghostfat.c
+++ b/src/usb/uf2/ghostfat.c
@@ -406,6 +406,12 @@ int write_block (uint32_t block_no, uint8_t *data, WriteState *state)
 
   if ( !is_uf2_block(bl) ) return -1;
 
+  if (bl->blockNo == 0) {
+    state->numBlocks = bl->numBlocks;
+    state->numWritten = 0;
+    memset(state->writtenMask, 0, sizeof(state->writtenMask));
+  }
+
   switch ( bl->familyID )
   {
 


### PR DESCRIPTION
wr_state resides in SRAM and may contain stale values. Resetting it on the first block ensures correct state and valid data.

## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [ ] Please provide specific title of the PR describing the change
- [ ] If you are adding an new boards, please make sure
  - [ ] Provide link to your allocated VID/PID if applicable
  - [ ] `UF2_BOARD_ID` in your board.h follow correct format from [uf2 specs](https://github.com/microsoft/uf2#files-exposed-by-bootloaders)

*This checklist items that are not applicable to your PR can be deleted.*

-----------

## Description of Change

Please describe your proposed Pull Request and it's impact.
