### PR TITLE
Seeed Xiao BLE boards: enable 2nd LED

### DIFF
--- a/src/boards/xiao_nrf52840_ble/board.h
+++ b/src/boards/xiao_nrf52840_ble/board.h
@@ -28,10 +28,10 @@
 /*------------------------------------------------------------------*/
 /* LED
  *------------------------------------------------------------------*/
-// The board has 3 leds, but changing the number here causes OTA issues.
-#define LEDS_NUMBER      1
-#define LED_PRIMARY_PIN  PINNUM(0, 26)
-#define LED_STATE_ON     0
+#define LEDS_NUMBER       2
+#define LED_PRIMARY_PIN   PINNUM(0, 26) // red
+#define LED_SECONDARY_PIN PINNUM(0, 6) // blue
+#define LED_STATE_ON      0
 
 #define NEOPIXELS_NUMBER 0
 

--- a/src/boards/xiao_nrf52840_ble_sense/board.h
+++ b/src/boards/xiao_nrf52840_ble_sense/board.h
@@ -28,10 +28,10 @@
 /*------------------------------------------------------------------*/
 /* LED
  *------------------------------------------------------------------*/
-// The board has 3 leds, but changing the number here causes OTA issues.
-#define LEDS_NUMBER      1
-#define LED_PRIMARY_PIN  PINNUM(0, 26)
-#define LED_STATE_ON     0
+#define LEDS_NUMBER       2
+#define LED_PRIMARY_PIN   PINNUM(0, 26) // red
+#define LED_SECONDARY_PIN PINNUM(0, 6) // blue
+#define LED_STATE_ON      0
 
 #define NEOPIXELS_NUMBER 0
 


### PR DESCRIPTION
The Seeed Xiao Board has a small tripple LED w/ RGB colors.
The old code contained a three year old commend, saying
``` C
// The board has 3 leds, but changing the number here causes OTA issues.
```

Since other boards obviously don't have any problems, guess the comment is simply outdated. However if there were problems, say should be covered after cleanup of the button system (#383).

Unfortunately I'm not able to compile and test this PR on my own.

- [ ] Test on board required, since this are no separated LED, but a combined part on PCB.
- [ ] May a quick test, OTA is not effected by this change (disprove old code commend) 