### PR TITLE
fix: list supported boards when BOARD is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,20 @@ PYTHON = python
 # local customization
 -include Makefile.user
 
+# Select the board before loading board-specific configuration.
+BOARD_LIST := $(sort $(notdir $(patsubst %/,%,$(dir $(wildcard src/boards/*/board.mk)))))
+
+ifeq ($(BOARD),)
+  $(info You must provide a BOARD parameter with 'BOARD=')
+  $(info Supported boards are:)
+  $(foreach b,$(BOARD_LIST),$(info - $(b)))
+  $(error BOARD not defined)
+else ifeq ($(filter $(BOARD),$(BOARD_LIST)),)
+  $(info Unknown board '$(BOARD)'. Supported boards are:)
+  $(foreach b,$(BOARD_LIST),$(info - $(b)))
+  $(error Invalid BOARD specified)
+endif
+
 # Board specific
 -include src/boards/$(BOARD)/board.mk
 


### PR DESCRIPTION
Fixes #392

Commit `2d68ec5` moved board-specific configuration earlier in the Makefile and removed the existing board validation block. As a result, running bare `make` reaches the MCU selector with an empty `MCU_SUB_VARIANT` and reports `Sub Variant is unknown` instead of showing the supported boards.

This restores validation before `board.mk` is loaded. The supported list is derived from actual `src/boards/*/board.mk` files, so it stays current as boards are added or removed. Missing and invalid `BOARD` values now both produce actionable output and preserve a nonzero exit.

Verification with GNU Make 4.3:

- bare `make` lists all 49 supported boards and exits with `BOARD not defined`
- `make BOARD=not_a_board` lists the same choices and exits with `Invalid BOARD specified`
- `make -n BOARD=feather_nrf52840_express clean`
- `make -n BOARD=feather_nrf52832 clean`

