### PR TITLE
boards: support common-cathode PWM RGB LED

### DIFF
--- a/src/boards/boards.c
+++ b/src/boards/boards.c
@@ -366,6 +366,15 @@ void led_pwm_teardown(void) {
 }
 
 void led_pwm_duty_cycle(uint32_t led_index, uint16_t duty_cycle) {
+  // nRF52 PWM (Up mode) drives the pin HIGH for the portion of the period
+  // below duty; with duty == 0 the pin sits HIGH. The LED logic here assumes
+  // "larger duty == brighter", which matches a common-anode LED (the pin
+  // sinks current to light it). A common-cathode LED is driven the opposite
+  // way, so invert the duty when LED_RGB_COMMON_CATHODE is defined. Boards
+  // default to common-anode (upstream behavior) when the macro is undefined.
+#ifdef LED_RGB_COMMON_CATHODE
+  duty_cycle = 0xff - duty_cycle;
+#endif
   led_duty_cycles[led_index] = duty_cycle;
   nrf_pwm_event_clear(NRF_PWM0, NRF_PWM_EVENT_SEQEND0);
   nrf_pwm_task_trigger(NRF_PWM0, NRF_PWM_TASK_SEQSTART0);
@@ -385,7 +394,7 @@ void led_tick(void) {
     cycle = primary_cycle_length - cycle;
   }
   uint16_t duty_cycle = 0x4f * cycle / half_cycle;
-  #if LED_STATE_ON == 1
+  #if LED_STATE_ON == 1 && !defined(LED_RGB_COMMON_CATHODE)
   duty_cycle = 0xff - duty_cycle;
   #endif
   led_pwm_duty_cycle(LED_PRIMARY, duty_cycle);
@@ -397,7 +406,7 @@ void led_tick(void) {
       cycle = secondary_cycle_length - cycle;
   }
   duty_cycle = 0x8f * cycle / half_cycle;
-  #if LED_STATE_ON == 1
+  #if LED_STATE_ON == 1 && !defined(LED_RGB_COMMON_CATHODE)
   duty_cycle = 0xff - duty_cycle;
   #endif
   led_pwm_duty_cycle(LED_SECONDARY, duty_cycle);


### PR DESCRIPTION
## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [x] Please provide specific title of the PR describing the change

-----------

## Description of Change

The PWM LED driver assumes a common-anode LED: on nRF52 PWM (Up mode) duty == 0 leaves the pin HIGH, so "larger duty == brighter" only holds when the pin sinks current (common-anode). A common-cathode RGB LED is driven the opposite way and ends up fully lit with no state response.

Add an opt-in LED_RGB_COMMON_CATHODE macro. When defined, the duty is inverted in led_pwm_duty_cycle() and the redundant LED_STATE_ON inversion in led_tick() is skipped to avoid a double inversion. When undefined (default) behavior is unchanged from upstream (common-anode).

Verified on a common-cathode RGB board: previously all three channels stayed fully lit; with the fix the status color shows and the primary LED breathes correctly. Common-anode boards (e.g. particle_argon, feather_nrf52840_express) still build and behave identically.
