### PR TITLE
Add Sparkfun Pro nRF52840 Mini board

### DIFF
--- a/src/boards/sparkfun_nrf52840_mini/board.h
+++ b/src/boards/sparkfun_nrf52840_mini/board.h
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ha Thach for Adafruit Industries
+ * Copyright (c) 2026 Justin Gerace
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef _SPARKFUN_NRF52840_MINI_H_
+#define _SPARKFUN_NRF52840_MINI_H_
+
+/*------------------------------------------------------------------*/
+/* LED
+ *------------------------------------------------------------------*/
+#define LEDS_NUMBER           1
+#define LED_PRIMARY_PIN       PINNUM(0, 7)
+#define LED_STATE_ON          1
+
+/*------------------------------------------------------------------*/
+/* BUTTON
+ *------------------------------------------------------------------*/
+#define BUTTON_DFU            PINNUM(0, 13)       // Primary Button
+#define BUTTON_DFU_OTA        PINNUM(0, 18)       // unusable: RESET
+#define BUTTON_PULL           NRF_GPIO_PIN_PULLUP
+
+//--------------------------------------------------------------------+
+// BLE OTA
+//--------------------------------------------------------------------+
+#define BLEDIS_MANUFACTURER   "SparkFun"
+#define BLEDIS_MODEL          "nRF52840 Mini"
+
+//--------------------------------------------------------------------+
+// USB
+//--------------------------------------------------------------------+
+#define USB_DESC_VID          0x1B4F
+#define USB_DESC_UF2_PID      0x0029
+#define USB_DESC_CDC_ONLY_PID 0x002A
+
+//------------- UF2 -------------//
+#define UF2_PRODUCT_NAME      "SparkFun Pro nRF52840 Mini"
+#define UF2_VOLUME_LABEL      "SFNRF52BOOT"
+#define UF2_BOARD_ID          "SparkFun-Pro-nRF52840-Mini"
+#define UF2_INDEX_URL         "https://www.sparkfun.com/products/15025"
+
+#endif /* _SPARKFUN_NRF52840_MINI_H_ */

--- a/src/boards/sparkfun_nrf52840_mini/board.mk
+++ b/src/boards/sparkfun_nrf52840_mini/board.mk
@@ -1,0 +1,1 @@
+MCU_SUB_VARIANT = nrf52840

--- a/src/boards/sparkfun_nrf52840_mini/pinconfig.c
+++ b/src/boards/sparkfun_nrf52840_mini/pinconfig.c
@@ -1,0 +1,19 @@
+#include "boards.h"
+#include "uf2/configkeys.h"
+
+__attribute__((used, section(".bootloaderConfig")))
+const uint32_t bootloaderConfig[] =
+{
+  /* CF2 START */
+  CFG_MAGIC0, CFG_MAGIC1,                       // magic
+  5, 100,                                       // used entries, total entries
+
+  204, 0x100000,                                // FLASH_BYTES = 0x100000
+  205, 0x40000,                                 // RAM_BYTES = 0x40000
+  208, (USB_DESC_VID << 16) | USB_DESC_UF2_PID, // BOOTLOADER_BOARD_ID = USB VID+PID, used for verification when updating bootloader via uf2
+  209, 0xada52840,                              // UF2_FAMILY = 0xada52840
+  210, 0x20,                                    // PINS_PORT_SIZE = PA_32
+
+  0, 0, 0, 0, 0, 0, 0, 0
+  /* CF2 END */
+};

--- a/supported_boards.md
+++ b/supported_boards.md
@@ -53,6 +53,7 @@
 | raytac_mdbt50q_db_40 | Raytac MDBT50Q Demo Board 40 | 0x239A:0x00BB | https://www.raytac.com/product/ins.php?index_id=81 |
 | raytac_mdbt50q_rx | Raytac MDBT50Q-RX | 0x239A:0x010B | https://www.adafruit.com/product/5199 |
 | sparkfun_nrf52840_micromod | SparkFun MicroMod nRF52840 | 0x1B4F:0x0022 | https://www.sparkfun.com/products/16984 |
+| sparkfun_nrf52840_mini | SparkFun Pro nRF52840 Mini | 0x1B4F:0x0029 | https://www.sparkfun.com/products/15025 |
 | t1000_e | Seeed T1000-E for Meshtastic | 0x2886:0x0057 | https://www.seeedstudio.com/SenseCAP-Card-Tracker-T1000-E-for-Meshtastic-p-5913.html |
 | waveshare_nrf52840_eval | Waveshare nRF52840 Eval | 0x239A:0x0029 | https://www.waveshare.com/wiki/NRF52840_Eval_Kit |
 | xiao_nrf52840_ble | Seeed XIAO nRF52840 | 0x2886:0x0044 | https://www.seeedstudio.com/ |


### PR DESCRIPTION
## Checklist

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

- [x] Please provide specific title of the PR describing the change
- [x] If you are adding an new boards, please make sure
  - [x] Provide link to your allocated VID/PID if applicable
  - [x] `UF2_BOARD_ID` in your board.h follow correct format from [uf2 specs](https://github.com/microsoft/uf2#files-exposed-by-bootloaders)

*This checklist items that are not applicable to your PR can be deleted.*

-----------

## Description of Change

This change adds a new board definition for the SparkFun Pro nRF52840 Mini board. Tested and confirmed to work on my own board, including the LED and the BOOT button.

VID/PID and pin configuration is based on SparkFun's documentation:
- Arduino board definition (VID/PID): https://github.com/sparkfun/nRF52840_Breakout_MDBT50Q/blob/46f154b42a57c1eed5dd1d212e41cef3c25b264b/Firmware/Arduino/sparkfun_boards.txt#L7-L13
- Pin definitions: https://github.com/sparkfun/nRF52840_Breakout_MDBT50Q/blob/46f154b42a57c1eed5dd1d212e41cef3c25b264b/Firmware/Arduino/variants/sparkfun_nrf52840_mini/variant.h (although note this board doesn't actually have two user-controllable LEDs, just a single one, that seems to be a mistake in the upstream source)